### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+go:
+- 1.x
+
+install:
+- go get github.com/gorilla/mux
+- go get github.com/mattn/go-sqlite3
+- go get github.com/jinzhu/gorm
+- go build
+
+deploy:
+  provider: releases
+  api_key:
+    secure: jMeiHFBLXNsdrbVcuPY2yY84jJE7Th7xwSo7PaeDTPATo+W3SpPXpNi1VHjh+mwIg69rK7fF8EIDWXGsTApUib8UrXZj9mIJu154fn3LyPa07EWVgD874sFIYat2rxfuvJT3pK+nX7j3Gpj7HAGgiRGWmDq6LdA/ETOk2KDBdqeSpHTHSVGqHX5y6hA+z8tTQa/S8g4Ujb/coEDjT2umdQznUJjxoFjpOD0cyoCTv7tVho8qPC72FoSNGXb4C4EnjfxQRp/okNWJTHdTRSva9TstC/+u0oy7qEcpnNLm7OTHmBL53hbWcoiE3T60FObUiRgB7JA5SrC05P3s/nVLoFk2g1pQvDfR1pgHCIFqQZhcg/Y6XaxdP1U34RdvknoxflR7xZ9j+DNg14IcljAfcidpMZh459Ur/XU1kCXrY/lbAyA9PE48XWLHg/FXAPmbDpaHp3U0rPeRFrm6hfnNKL14TV2hL5oFMpTCNzrQwrsGMf2ROMk9u/j7FQSGKQyOcyt2HCgEZCKYAq+aUtp0cg4EVhhWYQFtuU5TOoWaYH7HDPCVIkSUpwAbwlGoOcK/WVRJatZQjZwS5zLJ6J2Vq+ekMu5wstTlInau4sRwOoU8SOJPxx1+XQMM9KX7G3H3ico/ZqKZNoKytaqHrRPfI8EX2R1ADLg5o9wCfWRofOQ=
+  file: nyaa
+  skip_cleanup: true
+  overwrite: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nyaa replacement
+# Nyaa replacement [![Build Status](https://travis-ci.org/ewhal/nyaa.svg?branch=master)](https://travis-ci.org/ewhal/nyaa)
 
 ## Motivation
 The aim of this project is to write a fully featured nyaa replacement in golang


### PR DESCRIPTION
Add Travis CI automatically build

Step to enable travis-ci:
1. Connect from gihub to travis-ci: https://github.com/integrations/travis-ci
2. Enable project in travis-ci.com
3. To make travis-ci push the release, create and push a tag to github
4. Done