### PR TITLE
Working in the torrent list layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -48,10 +48,18 @@ a {
 	text-decoration : none;
 }
 
-.torrentName {
-    font-weight: bold;
-    overflow: hidden;
-    padding-bottom: 3px;
-    padding-top: 3px;
-    word-wrap: break-word;
+.torrent-info .name {
+	font-weight: bold;
+	overflow: hidden;
+	padding-bottom: 3px;
+	padding-top: 3px;
+	word-wrap: break-word;
+}
+
+.torrent-info .hash {
+	font-family: monospace;
+}
+
+.torrent-info .filesize {
+	white-space: nowrap;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,23 +11,33 @@
               <th>Links</th>
           </tr>
           {{ range .ListTorrents}}
-          <tr {{if eq .Status 2}}class="remake"{{end}}
-              {{if eq .Status 3}}class="trusted"{{end}}
-              {{if eq .Status 4}}class="aplus"{{end}}>
-              <td><a href="{{$.URL.Parse (printf "/search?c=%s_%s" .Category.Id .Sub_Category.Id) }}"><img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .Sub_Category.Id) }}"></td>
-              <td class="torrentName"><a href="{{genRoute "view_torrent" "id" .Id }}">{{.Name}}</a></td>
-              <td>{{.Hash}}</td>
-              <td>{{.Date}}</td>
-              <td>{{.Filesize}}</td>
-
-              <td><a href="{{.Magnet}}" target="_blank" title="Magnet link"><span class="glyphicon glyphicon-magnet" aria-hidden="true"></span></a>
-              <a href="https://itorrents.org/torrent/{{.Hash}}.torrent" title="Torrent file"><span class="glyphicon glyphicon-floppy-save" aria-hidden="true"></span></a>
+          <tr class="torrent-info
+              {{if eq .Status 2}}remake{{end}}
+              {{if eq .Status 3}}trusted{{end}}
+              {{if eq .Status 4}}aplus{{end}}">
+              <td>
+                  <a href="{{$.URL.Parse (printf "/search?c=%s_%s" .Category.Id .Sub_Category.Id) }}">
+                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .Sub_Category.Id) }}">
+                  </a>
               </td>
-
-
+              <td class="name">
+                  <a href="{{genRoute " view_torrent" "id" .Id }}">
+                      {{.Name}}
+                  </a>
+              </td>
+              <td class="hash">{{.Hash}}</td>
+              <td class="date">{{.Date}}</td>
+              <td class="filesize">{{.Filesize}}</td>
+              <td>
+                  <a href="{{.Magnet}}" target="_blank" title="Magnet link">
+                      <span class="glyphicon glyphicon-magnet" aria-hidden="true"></span>
+                  </a>
+                  <a href="https://itorrents.org/torrent/{{.Hash}}.torrent" title="Torrent file">
+                      <span class="glyphicon glyphicon-floppy-save" aria-hidden="true"></span>
+                  </a>
+              </td>
           </tr>
           {{end}}
-
       </table>
       <nav class="torrentNav" aria-label="Page navigation">
           <ul class="pagination">


### PR DESCRIPTION
Changes:
- Hashes use a monospaced font, since they have the same text-width;
- Filesize does not wrap (stay always on the same line)