### PR TITLE
Additional trackers

### DIFF
--- a/config/trackers.go
+++ b/config/trackers.go
@@ -1,5 +1,5 @@
 package config
 
 const (
-	Trackers = "&tr=udp://tracker.coppersurfer.tk:6969&tr=udp://zer0day.to:1337/announce&tr=udp://tracker.leechers-paradise.org:6969&tr=udp://explodie.org:6969&tr=udp://tracker.opentrackr.org:1337&tr=http://tracker.baka-sub.cf/announce"
+	Trackers = "&tr=udp://tracker.coppersurfer.tk:6969&tr=udp://zer0day.to:1337/announce&tr=udp://tracker.leechers-paradise.org:6969&tr=udp://explodie.org:6969&tr=udp://tracker.opentrackr.org:1337&tr=udp://tracker.pirateparty.gr:6969/announce&tr=udp://tracker.internetwarriors.net:1337/announce&tr=udp://eddie4.nl:6969/announce&tr=http://mgtracker.org:6969/announce&tr=http://tracker.baka-sub.cf/announce"
 )


### PR DESCRIPTION
Added tracker.pirateparty.gr, tracker.internetwarriors.net, eddie4.nl, and mgtracker.org
Each of these trackers returned a large peer list when added to an existing torrent and the more the better.