### PR TITLE
Return status code 404 on 404 page

### DIFF
--- a/router/notFoundHandler.go
+++ b/router/notFoundHandler.go
@@ -15,6 +15,8 @@ func init() {
 }
 
 func NotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+
 	searchForm := NewSearchForm()
 	searchForm.HideAdvancedSearch = true
 	err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{Navigation{}, searchForm, r.URL, mux.CurrentRoute(r)})


### PR DESCRIPTION
The NotFoundHandler previously returned status code 200
because WriteHeader wasn't called.