### PR TITLE
CSS rework - additive night mode CSS, and use CSS background image for night mode toggle

### DIFF
--- a/public/css/style-night.css
+++ b/public/css/style-night.css
@@ -1,8 +1,4 @@
-/* Night mode switcher  */
-.nightswitch > img {
-    width: 24px;
-}
-
+/*Don't make changes to layout here, only colours*/
 /* Torrent status colors */
 .remake {
   background-color: #795c46;
@@ -17,10 +13,7 @@
 /* modified copy of NyaaTorrent theme */
 #mainmenu {
     background: #263238;
-    position: fixed;
     color: #f2f2f2;
-    width: 100%;
-    z-index: 4;
     border: 0px solid #263238;
 }
 
@@ -29,7 +22,6 @@
 }
 
 #container {
-    padding-top: 1.25em;
     background-color: #29363d;
 }
 
@@ -44,14 +36,8 @@
 body {
     background-color:#282A2E;
     color: #eff5f5;
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
 }
 
-.torrentNav {
-	text-align: center;
-}
 
 .pagination > .active > a {
     background: #ececec;
@@ -70,143 +56,15 @@ a {
     border-color: #b294bb;
 }
 
-.download-btn {
-    font-size: 24px;
-}
-
-.table-borderless > tbody > tr > td,
-.table-borderless > tbody > tr > th,
-.table-borderless > tfoot > tr > td,
-.table-borderless > tfoot > tr > th,
-.table-borderless > thead > tr > td,
-.table-borderless > thead > tr > th {
-    border: none;
-}
-
-.torrent-info .name {
-	font-weight: bold;
-	overflow: hidden;
-	padding-bottom: 3px;
-	padding-top: 3px;
-	word-wrap: break-word;
-}
-
-.torrent-hash {
-	font-family: monospace;
-}
-
-.torrent-info .filesize {
-	white-space: nowrap;
-}
-
-.comment-row td:first-of-type {
-	vertical-align: top;
-	text-align: right;
-}
-
-/* Table style & fixes */
-.table > tbody > tr > td {
-    /* fix bootstrap uglyness */
-    vertical-align: middle;
-}
-
-.table > tbody > tr > th, .table > tbody > tr > td {
-	padding: 4px;
-}
-
-.captcha-container {
-	display: grid;
-	grid-template-rows: auto;
-	grid-template-columns: 240px;
-}
-
-tr.torrent-info td.date {
-	white-space: nowrap;
-}
-
-.custom-table-hover > tbody > tr:hover {
-	opacity: 0.82;
-}
-
 .comment-row {
 	border-top: 1px solid #ddd;
-}
-
-div.container div.blockBody:nth-of-type(2) table{table-layout:fixed;}
-div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:first-of-type, div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type(5){width:10%;}
-div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type(3){width:15%;}
-div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type(4){width:19%;}
-div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:last-of-type{width:6%;}
-
-/* Mobile-friendly main table */
-@media only screen and (max-width: 700px) {
-	table, thead, tbody, tr {
-		display: block;
-	}
-
-	th {
-		display: none;
-	}
-
-	td {
-		display: inline-block;
-	}
-
-	td:nth-of-type(1), td:nth-of-type(2) {
-		display: block;
-	}
-
-	.table > tbody > tr > td {
-		border: none;
-	}
-}
-
-/* Credit to bootsnipp.com for the css for the color graph */
-.colorgraph {
-  height: 5px;
-  border-top: 0;
-  background: #c4e17f;
-  border-radius: 5px;
-  background-image: -webkit-linear-gradient(left, #c4e17f, #c4e17f 12.5%, #f7fdca 12.5%, #f7fdca 25%, #fecf71 25%, #fecf71 37.5%, #f0776c 37.5%, #f0776c 50%, #db9dbe 50%, #db9dbe 62.5%, #c49cde 62.5%, #c49cde 75%, #669ae1 75%, #669ae1 87.5%, #62c2e4 87.5%, #62c2e4);
-  background-image: -moz-linear-gradient(left, #c4e17f, #c4e17f 12.5%, #f7fdca 12.5%, #f7fdca 25%, #fecf71 25%, #fecf71 37.5%, #f0776c 37.5%, #f0776c 50%, #db9dbe 50%, #db9dbe 62.5%, #c49cde 62.5%, #c49cde 75%, #669ae1 75%, #669ae1 87.5%, #62c2e4 87.5%, #62c2e4);
-  background-image: -o-linear-gradient(left, #c4e17f, #c4e17f 12.5%, #f7fdca 12.5%, #f7fdca 25%, #fecf71 25%, #fecf71 37.5%, #f0776c 37.5%, #f0776c 50%, #db9dbe 50%, #db9dbe 62.5%, #c49cde 62.5%, #c49cde 75%, #669ae1 75%, #669ae1 87.5%, #62c2e4 87.5%, #62c2e4);
-  background-image: linear-gradient(to right, #c4e17f, #c4e17f 12.5%, #f7fdca 12.5%, #f7fdca 25%, #fecf71 25%, #fecf71 37.5%, #f0776c 37.5%, #f0776c 50%, #db9dbe 50%, #db9dbe 62.5%, #c49cde 62.5%, #c49cde 75%, #669ae1 75%, #669ae1 87.5%, #62c2e4 87.5%, #62c2e4);
-}
-
-.center-image {
-	max-width: 100%;
-	max-height: 80vh;
-}
-
-/* the curved edges triggered my autism */
-.navbar {
-    border-radius: 0px;
 }
 
 :target {
     background-color: #585b4f;
 }
 
-#mainmenu button .search_text {
-	display: none;
-}
-#mainmenu .navbar-form select.form-control
-{
-	width: 12rem;
-}
-.special-img 
-{
-    position: relative;
-    top: -5px;
-    float: left;
-    left: -5px;
-}
-
-#mainmenu .badgemenu {
-	padding-top: 0;
-}
-
-/* fix the dropdown member menu */
+/* style the dropdown member menu */
 .nav > .dropdown.open, .profile-image[aria-expanded="true"], .nav ul.dropdown-menu {
 	background: #282A2E !important;
 }

--- a/public/css/style-night.css
+++ b/public/css/style-night.css
@@ -205,3 +205,11 @@ div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:last-of-typ
 #mainmenu .badgemenu {
 	padding-top: 0;
 }
+
+/* fix the dropdown member menu */
+.nav > .dropdown.open, .profile-image[aria-expanded="true"], .nav ul.dropdown-menu {
+	background: #282A2E !important;
+}
+.dropdown-menu > li > a:focus, .dropdown-menu > li > a:hover {
+	background: #263238;
+}

--- a/public/css/style-night.css
+++ b/public/css/style-night.css
@@ -66,7 +66,7 @@ a {
 
 /* style the dropdown member menu */
 .nav > .dropdown.open, .profile-image[aria-expanded="true"], .nav ul.dropdown-menu {
-	background: #282A2E !important;
+	background: #282A2E;
 }
 .dropdown-menu > li > a:focus, .dropdown-menu > li > a:hover {
 	background: #263238;

--- a/public/css/style-night.css
+++ b/public/css/style-night.css
@@ -66,3 +66,7 @@ a {
 .dropdown-menu > li > a:focus, .dropdown-menu > li > a:hover {
 	background: #263238;
 }
+/* Night mode switcher  */
+#mainmenu a.nightswitch {
+    background-image: url(/img/moon.png);
+}

--- a/public/css/style-night.css
+++ b/public/css/style-night.css
@@ -10,7 +10,7 @@
   background-color: #487589;
 }
 
-/* modified copy of NyaaTorrent theme */
+
 #mainmenu {
     background: #263238;
     color: #f2f2f2;
@@ -48,16 +48,11 @@ body {
 /* Links, Text */
 a {
 	color: #81a2be;
-	text-decoration : none;
 }
 .btn-success {
     color: #fff;
     background-color: #b294bb;
     border-color: #b294bb;
-}
-
-.comment-row {
-	border-top: 1px solid #ddd;
 }
 
 :target {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,7 +1,4 @@
-/* Night mode switcher  */
-.nightswitch > img {
-    width: 24px;
-}
+
 
 /* Torrent status colors */
 .remake {
@@ -318,4 +315,12 @@ div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:last-of-typ
   padding: 20px;
   background: #fff;
   min-height: 460px;
+}
+/* Night mode switcher  */
+#mainmenu a.nightswitch {
+    background: transparent url(/img/sun.png) no-repeat;
+    background-size: 24px;
+    margin-top: 10px;
+    margin-left: 3px;
+    width: 24px;
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,17 +2,14 @@
 var night = localStorage.getItem("night");
 if (night == "true") {
     $("head").append('<link id="style-dark" rel="stylesheet" type="text/css" href="/css/style-night.css">');
-    $("#nighticon")[0].src = "/img/sun.png";
 }
 
 function toggleNightMode() {
     var night = localStorage.getItem("night");
     if(night == "true") {
         $("#style-dark")[0].remove()
-        $("#nighticon")[0].src = "/img/moon.png";
     } else {
         $("head").append('<link id="style-dark" rel="stylesheet" type="text/css" href="/css/style-night.css">');
-        $("#nighticon")[0].src = "/img/sun.png";
     }
     localStorage.setItem("night", (night == "true") ? "false" : "true");
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,17 +1,17 @@
 // Night mode
 var night = localStorage.getItem("night");
 if (night == "true") {
-    $("#style")[0].href = "/css/style-night.css";
+    $("head").append('<link id="style-dark" rel="stylesheet" type="text/css" href="/css/style-night.css">');
     $("#nighticon")[0].src = "/img/sun.png";
 }
 
 function toggleNightMode() {
     var night = localStorage.getItem("night");
     if(night == "true") {
-        $("#style")[0].href = "/css/style.css";
+        $("#style-dark")[0].remove()
         $("#nighticon")[0].src = "/img/moon.png";
     } else {
-        $("#style")[0].href = "/css/style-night.css";
+        $("head").append('<link id="style-dark" rel="stylesheet" type="text/css" href="/css/style-night.css">');
         $("#nighticon")[0].src = "/img/sun.png";
     }
     localStorage.setItem("night", (night == "true") ? "false" : "true");

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,7 @@
                       <span class="icon-bar"></span>
                   </button>
                   <a class="navbar-brand" href="{{.URL.Parse "/"}}">Nyaa Pantsu</a>
-                  <a class="navbar-brand hidden-md pull-right nightswitch" href="javascript:toggleNightMode();" ><img id="nighticon" src="/img/moon.png"></a>
+                  <a class="navbar-brand hidden-md pull-right nightswitch" href="javascript:toggleNightMode();" ></a>
               </div>
               <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                   <ul class="nav navbar-nav">


### PR DESCRIPTION
Currently, style-night.css is a copypaste of style.css, but with different colours. This is very bad design, as any layout changes must be replicated on both files. Already this has caused a difference in layout on the dark theme. My change removes all layout instructions from the dark mode css, and adds it on top of the existing css. This guarantees that no layout changes are made by dark mode. 

Also fixed the dropdowns in night mode.

Also displaying the night-mode toggle button with a css background instead of an img. This nets 2 lines less JS.