### PR TITLE
remove unnecesary check and fix anon comment

### DIFF
--- a/router/viewTorrentHandler.go
+++ b/router/viewTorrentHandler.go
@@ -46,9 +46,7 @@ func PostCommentHandler(w http.ResponseWriter, r *http.Request) {
 	content := p.Sanitize(r.FormValue("comment"))
 
 	idNum, err := strconv.Atoi(id)
-	if currentUser.ID <= 0 {
-		http.Error(w, "Invalid user ID", http.StatusInternalServerError)
-	}
+
 	userID := currentUser.ID
 	comment := model.Comment{TorrentID: uint(idNum), UserID: userID, Content: content, CreatedAt: time.Now()}
 	


### PR DESCRIPTION
We don't need this check because getUser is secure and if that gets compromised we're pwned as af anyways.

This fixes the 500 when commenting as an anon