### PR TITLE
Fix broken menu on user profile page and fix advanced search showing on profile page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sqlite
+*.db-journal
 *.db
 *.sql
 main

--- a/router/router.go
+++ b/router/router.go
@@ -37,6 +37,7 @@ func init() {
 	gzipUserLogoutHandler := handlers.CompressHandler(http.HandlerFunc(UserLogoutHandler))
 	gzipUserProfileHandler := handlers.CompressHandler(http.HandlerFunc(UserProfileHandler))
 	gzipUserFollowHandler := handlers.CompressHandler(http.HandlerFunc(UserFollowHandler))
+	gzipUserDetailsHandler := handlers.CompressHandler(http.HandlerFunc(UserDetailsHandler))
 	gzipUserProfileFormHandler := handlers.CompressHandler(http.HandlerFunc(UserProfileFormHandler))
 
 	gzipIndexModPanel := handlers.CompressHandler(http.HandlerFunc(IndexModPanel))
@@ -81,7 +82,8 @@ func init() {
 	Router.Handle("/user/logout", gzipUserLogoutHandler).Name("user_logout")
 	Router.Handle("/user/{id}/{username}", wrapHandler(gzipUserProfileHandler)).Name("user_profile").Methods("GET")
 	Router.Handle("/user/{id}/{username}/follow", gzipUserFollowHandler).Name("user_follow").Methods("GET")
-	Router.Handle("/user/{id}/{username}", wrapHandler(gzipUserProfileFormHandler)).Name("user_profile").Methods("POST")
+	Router.Handle("/user/{id}/{username}/edit", wrapHandler(gzipUserDetailsHandler)).Name("user_profile_details").Methods("GET")
+	Router.Handle("/user/{id}/{username}/edit", wrapHandler(gzipUserProfileFormHandler)).Name("user_profile_edit").Methods("POST")
 
 	Router.Handle("/mod", gzipIndexModPanel).Name("mod_index")
 	Router.Handle("/mod/torrents", gzipTorrentsListPanel).Name("mod_tlist")

--- a/router/userHandler.go
+++ b/router/userHandler.go
@@ -64,7 +64,9 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 			b := form.UserForm{}
 			modelHelper.BindValueForm(&b, r)
 			languages.SetTranslationFromRequest(viewProfileEditTemplate, r, "en-us")
-			htv := UserProfileEditVariables{&userProfile, b, form.NewErrors(), form.NewInfos(), NewSearchForm(), Navigation{}, currentUser, r.URL, mux.CurrentRoute(r)}
+			searchForm := NewSearchForm()
+			searchForm.HideAdvancedSearch = true
+			htv := UserProfileEditVariables{&userProfile, b, form.NewErrors(), form.NewInfos(), searchForm, Navigation{}, currentUser, r.URL, mux.CurrentRoute(r)}
 
 			err := viewProfileEditTemplate.ExecuteTemplate(w, "index.html", htv)
 			if err != nil {
@@ -77,7 +79,9 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 				err["errors"] = append(err["errors"], errUser.Error())
 			}
 			languages.SetTranslationFromRequest(viewUserDeleteTemplate, r, "en-us")
-			htv := UserVerifyTemplateVariables{err, NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
+			searchForm := NewSearchForm()
+			searchForm.HideAdvancedSearch = true
+			htv := UserVerifyTemplateVariables{err, searchForm, Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
 			errorTmpl := viewUserDeleteTemplate.ExecuteTemplate(w, "index.html", htv)
 			if errorTmpl != nil {
 				http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
@@ -90,7 +94,9 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 			if unfollow != nil {
 				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(T("user_unfollowed_msg"), userProfile.Username))
 			}
-			htv := UserProfileVariables{&userProfile, infosForm, NewSearchForm(), Navigation{}, currentUser, r.URL, mux.CurrentRoute(r)}
+			searchForm := NewSearchForm()
+			searchForm.HideAdvancedSearch = true
+			htv := UserProfileVariables{&userProfile, infosForm, searchForm, Navigation{}, currentUser, r.URL, mux.CurrentRoute(r)}
 
 			err := viewProfileTemplate.ExecuteTemplate(w, "index.html", htv)
 			if err != nil {

--- a/router/userHandler.go
+++ b/router/userHandler.go
@@ -54,25 +54,12 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 	userProfile, _, errorUser := userService.RetrieveUserForAdmin(id)
 	if errorUser == nil {
 		currentUser := GetUser(r)
-		view := r.URL.Query()["edit"]
 		follow := r.URL.Query()["followed"]
 		unfollow := r.URL.Query()["unfollowed"]
 		infosForm := form.NewInfos()
 		deleteVar := r.URL.Query()["delete"]
 
-		if (view != nil) && (userPermission.CurrentOrAdmin(currentUser, userProfile.ID)) {
-			b := form.UserForm{}
-			modelHelper.BindValueForm(&b, r)
-			languages.SetTranslationFromRequest(viewProfileEditTemplate, r, "en-us")
-			searchForm := NewSearchForm()
-			searchForm.HideAdvancedSearch = true
-			htv := UserProfileEditVariables{&userProfile, b, form.NewErrors(), form.NewInfos(), searchForm, Navigation{}, currentUser, r.URL, mux.CurrentRoute(r)}
-
-			err := viewProfileEditTemplate.ExecuteTemplate(w, "index.html", htv)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		} else if (deleteVar != nil) && (userPermission.CurrentOrAdmin(currentUser, userProfile.ID)) {
+		if (deleteVar != nil) && (userPermission.CurrentOrAdmin(currentUser, userProfile.ID)) {
 			err := form.NewErrors()
 			_, errUser := userService.DeleteUser(w, currentUser, id)
 			if errUser != nil {
@@ -115,6 +102,25 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+//Getting User Profile Details View
+func UserDetailsHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+	b := form.UserForm{}
+	userProfile, _, errorUser := userService.RetrieveUserForAdmin(id)
+	if errorUser == nil {
+		currentUser := GetUser(r)
+		modelHelper.BindValueForm(&b, r)
+		languages.SetTranslationFromRequest(viewProfileEditTemplate, r, "en-us")
+		searchForm := NewSearchForm()
+		searchForm.HideAdvancedSearch = true
+		htv := UserProfileEditVariables{&userProfile, b, form.NewErrors(), form.NewInfos(), searchForm, Navigation{}, currentUser, r.URL, mux.CurrentRoute(r)}
+		err := viewProfileEditTemplate.ExecuteTemplate(w, "index.html", htv)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
 // Getting View User Profile Update
 func UserProfileFormHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)

--- a/templates/user/profile.html
+++ b/templates/user/profile.html
@@ -26,13 +26,13 @@
 				<!-- SIDEBAR BUTTONS -->
 				<div class="profile-userbuttons">
 						{{if gt $.User.ID 0 }}
-						{{if not (CurrentUserIdentical $.User .ID) }}
-						{{if not (IsFollower . $.User)}}
-							<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-success btn-sm">{{ T "follow"}}</a>
-						{{else}}
-							<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-danger btn-sm">{{ T "unfollow"}}</a>
-						{{end}}
-						{{end}}
+							{{if not (CurrentUserIdentical $.User .ID) }}
+								{{if not (IsFollower . $.User)}}
+									<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-success btn-sm">{{ T "follow"}}</a>
+								{{else}}
+									<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-danger btn-sm">{{ T "unfollow"}}</a>
+								{{end}}
+							{{end}}
 						{{end}}
 					<!-- <button type="button" class="btn btn-danger btn-sm">Message</button> -->
 				</div>
@@ -46,13 +46,13 @@
 							{{T "torrents"}} </a>
 						</li>
 						{{if gt $.User.ID 0 }}
-						{{if CurrentOrAdmin $.User .ID }}
-						<li>
-							<a href="?edit">
-							<i class="glyphicon glyphicon-user"></i>
-							{{T "settings"}} </a>
-						</li>
-						{{end}}
+							{{if CurrentOrAdmin $.User .ID }}
+								<li>
+									<a href="?edit">
+									<i class="glyphicon glyphicon-user"></i>
+									{{T "settings"}} </a>
+								</li>
+							{{end}}
 						{{end}}
 					</ul>
 				</div>

--- a/templates/user/profile.html
+++ b/templates/user/profile.html
@@ -41,18 +41,15 @@
 				<div class="profile-usermenu">
 					<ul class="nav">
 						<li class="active">
-							<a href="#">
-							<i class="glyphicon glyphicon-home"></i>
-							{{T "torrents"}} </a>
+							<a href="{{ genRoute "user_profile" "id" ( print .ID ) "username" .Username }}"><i class="glyphicon glyphicon-home"></i>{{T "torrents"}}</a>
 						</li>
 						{{if gt $.User.ID 0 }}
-							{{if CurrentOrAdmin $.User .ID }}
-								<li>
-									<a href="?edit">
-									<i class="glyphicon glyphicon-user"></i>
-									{{T "settings"}} </a>
-								</li>
-							{{end}}
+						{{if CurrentOrAdmin $.User .ID }}
+						<li>
+							<a href="{{ genRoute "user_profile_details" "id" ( print .ID ) "username" .Username }}"><i class="glyphicon glyphicon-user"></i>{{T "settings"}}</a>
+
+						</li>
+						{{end}}
 						{{end}}
 					</ul>
 				</div>

--- a/templates/user/profile_edit.html
+++ b/templates/user/profile_edit.html
@@ -23,13 +23,13 @@
 				<!-- SIDEBAR BUTTONS -->
 				<div class="profile-userbuttons">
 						{{if gt $.User.ID 0 }}
-						{{if not (CurrentUserIdentical $.User .ID) }}
-						{{if not (IsFollower . $.User)}}
-							<a href="{{ genRoute "user_follow" "id" (print .ID)}}" class="btn btn-success btn-sm">{{ T "follow"}}</a>
-						{{else}}
-							<a href="{{ genRoute "user_follow" "id" (print .ID)}}" class="btn btn-danger btn-sm">{{ T "unfollow"}}</a>
-						{{end}}
-						{{end}}
+							{{if not (CurrentUserIdentical $.User .ID) }}
+								{{if not (IsFollower . $.User)}}
+									<a href="{{ genRoute "user_follow" "id" (print .ID) "username" .Username }}" class="btn btn-success btn-sm">{{ T "follow"}}</a>
+								{{else}}
+									<a href="{{ genRoute "user_follow" "id" (print .ID) "username" .Username }}" class="btn btn-danger btn-sm">{{ T "unfollow"}}</a>
+								{{end}}
+							{{end}}
 						{{end}}
 					<!-- <button type="button" class="btn btn-danger btn-sm">Message</button> -->
 				</div>
@@ -38,18 +38,14 @@
 				<div class="profile-usermenu">
 					<ul class="nav">
 						<li>
-							<a href="#">
-							<i class="glyphicon glyphicon-home"></i>
-							{{T "torrents"}} </a>
+							<a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}"><i class="glyphicon glyphicon-home"></i>{{T "torrents"}}</a>
 						</li>
 						{{if gt $.User.ID 0 }}
-						{{if CurrentOrAdmin $.User .ID }}
-						<li class="active">
-							<a href="?edit">
-							<i class="glyphicon glyphicon-user"></i>
-							{{T "settings"}} </a>
-						</li>
-						{{end}}
+							{{if CurrentOrAdmin $.User .ID }}
+								<li class="active">
+									<a href="{{ genRoute "user_profile_edit" "id" (print .ID) "username" .Username }}"><i class="glyphicon glyphicon-user"></i>{{T "settings"}}</a>
+								</li>
+							{{end}}
 						{{end}}
 					</ul>
 				</div>


### PR DESCRIPTION
Currently the left-hand menu on the user profile page is one-way only, it goes to the user settings page and won't go back to the settings list. I fix this by splitting user settings into a new route, `/edit`, so it's a bog standard page load.