### PR TITLE
Fix Quote Block comments, fiddled with Markdown

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -347,3 +347,12 @@ footer {
   max-width: 100%;
   height: auto;
 }
+
+/* Psuedo green-text fuckery. */
+#comments blockquote {
+	color: #789922;
+}
+#comments blockquote:before {
+	content: ">";
+}
+

--- a/util/markdown.go
+++ b/util/markdown.go
@@ -2,14 +2,39 @@ package util
 
 import (
 	"github.com/microcosm-cc/bluemonday"
-	"github.com/russross/blackfriday"
+	md "github.com/russross/blackfriday"
 
 	"html/template"
+	"strings"
 )
+//Some default rules, plus and minus some.
+var mdOptions = 0 |
+	md.EXTENSION_AUTOLINK |
+	md.EXTENSION_HARD_LINE_BREAK |
+	md.EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK |
+	md.EXTENSION_NO_INTRA_EMPHASIS |
+	md.EXTENSION_SPACE_HEADERS |
+	md.EXTENSION_STRIKETHROUGH
+
+var htmlFlags = 0 |
+	md.HTML_USE_XHTML |
+	md.HTML_SMARTYPANTS_FRACTIONS |
+	md.HTML_SAFELINK |
+	md.HTML_NOREFERRER_LINKS |
+	md.HTML_HREF_TARGET_BLANK
+
+func init() {
+	HtmlMdRenderer = md.HtmlRenderer(htmlFlags, "", "")
+}
+var HtmlMdRenderer md.Renderer
 
 // TODO: restrict certain types of markdown
 func MarkdownToHTML(markdown string) template.HTML {
-	unsafe := blackfriday.MarkdownCommon([]byte(markdown))
+	if len(markdown) >= 3) && markdown[:3] == "&gt;" {
+		markdown = ">" + markdown[3:]
+	}
+	markdown = strings.Replace(markdown,"\n&gt;","\n>")
+	unsafe := md.MarkdownOptions([]byte(markdown), HtmlMdRenderer, md.Options{Extensions: mdOptions})
 	html := bluemonday.UGCPolicy().SanitizeBytes(unsafe)
 	return template.HTML(html)
 }

--- a/util/markdown.go
+++ b/util/markdown.go
@@ -30,7 +30,7 @@ var HtmlMdRenderer md.Renderer
 
 // TODO: restrict certain types of markdown
 func MarkdownToHTML(markdown string) template.HTML {
-	if len(markdown) >= 3) && markdown[:3] == "&gt;" {
+	if len(markdown) >= 3 && markdown[:3] == "&gt;" {
 		markdown = ">" + markdown[3:]
 	}
 	markdown = strings.Replace(markdown,"\n&gt;","\n>")

--- a/util/markdown.go
+++ b/util/markdown.go
@@ -33,7 +33,7 @@ func MarkdownToHTML(markdown string) template.HTML {
 	if len(markdown) >= 3 && markdown[:3] == "&gt;" {
 		markdown = ">" + markdown[3:]
 	}
-	markdown = strings.Replace(markdown,"\n&gt;","\n>")
+	markdown = strings.Replace(markdown,"\n&gt;","\n>", -1)
 	unsafe := md.MarkdownOptions([]byte(markdown), HtmlMdRenderer, md.Options{Extensions: mdOptions})
 	html := bluemonday.UGCPolicy().SanitizeBytes(unsafe)
 	return template.HTML(html)


### PR DESCRIPTION
Greater-than (">") symbols were being filtered out by the sanitizer as they were saved to the database. Hopefully this will fix 'em. I considered using regexp, but thought that would be complete overkill.

On top of that, I fiddled with the way comments should render, the most important of these being that all links now have a `rel="noreferrer"`, you no longer need to have double line-breaks for a line-break to render, and links (at least those rendered from Markdown) now open a blank tab/window, instead of changing your current one.

That said... could someone test out the changes just to make sure it's working as intended? haha. I may have botched something for all I know.