### PR TITLE
Fixing the status filter (trusted should include a+ as well)

### DIFF
--- a/util/search/search.go
+++ b/util/search/search.go
@@ -111,9 +111,9 @@ func searchByQuery(r *http.Request, pagenum int, countAll bool) (
 		}
 		if search.Status != 0 {
 			if search.Status == common.FilterRemakes {
-				conditions = append(conditions, "status != ?")
+				conditions = append(conditions, "status > ?")
 			} else {
-				conditions = append(conditions, "status = ?")
+				conditions = append(conditions, "status >= ?")
 			}
 			parameters.Params = append(parameters.Params, strconv.Itoa(int(search.Status)+1))
 		}


### PR DESCRIPTION
The semantics for the status filter is "better than" and not "exactly as good as," so "Trusted" should include A+ (a.k.a "Trusted A+") torrents as well.