### PR TITLE
Redoing displayed Comment format.

### DIFF
--- a/templates/view.html
+++ b/templates/view.html
@@ -95,9 +95,9 @@
                     </div>
                     <div class="col-md-2">
                         {{printf "%d-%02d-%02d %02d:%02d" .Date.Year .Date.Month .Date.Day .Date.Hour .Date.Minute }}
-                        {{ /* output: "2017-05-01 15:30"
+                        {{/* output: "2017-05-01 15:30"
                             Went with "Year-Month-Day" because it's the most unambiguous.
-                            If you want it to be determined by where you're from, be my guest. */ }}
+                            If you want it to be determined by where you're from, be my guest. */}}
                     </div>
                     <div class="col-md-8">
                         {{.Content}}

--- a/templates/view.html
+++ b/templates/view.html
@@ -94,7 +94,10 @@
                         {{end}}
                     </div>
                     <div class="col-md-2">
-                        {{.Date.Year}}/{{.Date.Month}}/{{.Date.Day}}
+                        {{printf "%d-%02d-%02d %02d:%02d" .Date.Year .Date.Month .Date.Day .Date.Hour .Date.Minute }}
+                        {{ /* output: "2017-05-01 15:30"
+                            Went with "Year-Month-Day" because it's the most unambiguous.
+                            If you want it to be determined by where you're from, be my guest. */ }}
                     </div>
                     <div class="col-md-8">
                         {{.Content}}


### PR DESCRIPTION
It was showing it as 2017/May/11, which is just ugly. Also changed it up so month and day number are 0-padded, so instead of just "2017-5-11" it'll show "2017-05-11".