### PR TITLE
Now really fixing the status filter

### DIFF
--- a/util/search/search.go
+++ b/util/search/search.go
@@ -123,7 +123,7 @@ func searchByQuery(r *http.Request, pagenum int, countAll bool) (
 		}
 		if search.Status != 0 {
 			if search.Status == common.FilterRemakes {
-				conditions = append(conditions, "status > ?")
+				conditions = append(conditions, "status <> ?")
 			} else {
 				conditions = append(conditions, "status >= ?")
 			}


### PR DESCRIPTION
I managed to screw up in the last update. Normal is 0 and remake is 1, so that makes the "goodness order" of statuses non-monotonic, so I can't use the greater sign for filtering out remakes...