### PR TITLE
Fix empty comment (sanitize then trim and check)

### DIFF
--- a/router/viewTorrentHandler.go
+++ b/router/viewTorrentHandler.go
@@ -39,11 +39,6 @@ func PostCommentHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 
-	if strings.TrimSpace(r.FormValue("comment")) == "" {
-		http.Error(w, "comment empty", 406)
-		return
-	}
-
 	userCaptcha := captcha.Extract(r)
 	if !captcha.Authenticate(userCaptcha) {
 		http.Error(w, "bad captcha", 403)
@@ -51,6 +46,11 @@ func PostCommentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	currentUser := GetUser(r)
 	content := p.Sanitize(r.FormValue("comment"))
+
+	if strings.TrimSpace(content) == "" {
+		http.Error(w, "comment empty", 406)
+		return
+	}
 
 	idNum, err := strconv.Atoi(id)
 


### PR DESCRIPTION
Need to sanitize first and then check if it's empty.

Putting '<script></script>' in comment resulted in empty comments.