### PR TITLE
Change color for bg-danger and fix night theme flickering issue

### DIFF
--- a/public/css/style-night.css
+++ b/public/css/style-night.css
@@ -145,7 +145,7 @@ a:hover {
     color: #fff;
 }
 
-.bg-danger {
+.text-error {
   background: #29363d;
   color: #cf9fff;
 }

--- a/public/css/style-night.css
+++ b/public/css/style-night.css
@@ -144,3 +144,8 @@ a:hover {
 .modal-content .close {
     color: #fff;
 }
+
+.bg-danger {
+  background: #29363d;
+  color: #cf9fff;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -384,7 +384,7 @@ footer {
 	width: auto; /* Undo bootstrap's fixed width */
 }
 
-.bg-danger {
+.text-error {
   background: white;
   color: #cf9fff;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -383,3 +383,8 @@ footer {
 	font-size: smaller;
 	width: auto; /* Undo bootstrap's fixed width */
 }
+
+.bg-danger {
+  background: white;
+  color: #cf9fff;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,15 +1,10 @@
-// Night mode
 var night = localStorage.getItem("night");
-if (night == "true") {
-    $("head").append('<link id="style-dark" rel="stylesheet" type="text/css" href="/css/style-night.css">');
-}
-
 function toggleNightMode() {
     var night = localStorage.getItem("night");
     if(night == "true") {
-        $("#style-dark")[0].remove()
+        document.getElementById("style-dark").remove()
     } else {
-        $("head").append('<link id="style-dark" rel="stylesheet" type="text/css" href="/css/style-night.css">');
+        document.getElementsByTagName("head")[0].append(darkStyleLink);
     }
     localStorage.setItem("night", (night == "true") ? "false" : "true");
 }

--- a/templates/_profile_edit.html
+++ b/templates/_profile_edit.html
@@ -14,7 +14,7 @@
             <div class="col-lg-8">
               <input class="form-control" type="text" name="email" id="email" value="{{.Email}}">
 	 			{{ range (index $.FormErrors "email")}}
-					<p class="bg-danger">{{ . }}</p>
+					<p class="text-error">{{ . }}</p>
 				{{end}}
             </div>
           </div>
@@ -30,7 +30,7 @@
                 </select>
               </div>
 	 			{{ range (index $.FormErrors "language")}}
-					<p class="bg-danger">{{ . }}</p>
+					<p class="text-error">{{ . }}</p>
 				{{end}}
             </div>
           </div>
@@ -40,7 +40,7 @@
             <div class="col-md-8">
               <input class="form-control" name="current_password" id="current_password" type="password">
 	 			{{ range (index $.FormErrors "current_password")}}
-					<p class="bg-danger">{{ . }}</p>
+					<p class="text-error">{{ . }}</p>
 				{{end}}
             </div>
           </div>
@@ -50,7 +50,7 @@
             <div class="col-md-8">
               <input class="form-control" name="password" id="password" type="password">
 	 			{{ range (index $.FormErrors "password")}}
-					<p class="bg-danger">{{ . }}</p>
+					<p class="text-error">{{ . }}</p>
 				{{end}}
             </div>
           </div>
@@ -59,7 +59,7 @@
             <div class="col-md-8">
               <input class="form-control" name="password_confirmation" id="password_confirmation" type="password">
 	 			{{ range (index $.FormErrors "password_confirmation")}}
-					<p class="bg-danger">{{ . }}</p>
+					<p class="text-error">{{ . }}</p>
 				{{end}}
             </div>
           </div>
@@ -70,7 +70,7 @@
             <div class="col-md-8">
               <input class="form-control" name="username" id="username" type="text" value="{{.Username}}">
 	 			{{ range (index $.FormErrors "username")}}
-					<p class="bg-danger">{{ . }}</p>
+					<p class="text-error">{{ . }}</p>
 				{{end}}
             </div>
           </div>
@@ -86,7 +86,7 @@
                 </select>
               </div>
 	 			{{ range (index $.FormErrors "status")}}
-					<p class="bg-danger">{{ . }}</p>
+					<p class="text-error">{{ . }}</p>
 				{{end}}
             </div>
           </div>

--- a/templates/admin_index.html
+++ b/templates/admin_index.html
@@ -26,7 +26,18 @@
 
     <!-- Website CSS -->
     <link rel="stylesheet" id="style" href="{{.URL.Parse "/css/style.css"}}">
-
+    <script type="text/javascript">
+      // Night mode
+      var night = localStorage.getItem("night");
+      var darkStyleLink = document.createElement('link');
+      darkStyleLink.id = "style-dark";
+      darkStyleLink.rel = "stylesheet";
+      darkStyleLink.type = "text/css";
+      darkStyleLink.href = "/css/style-night.css"
+      if (night == "true") {
+          document.getElementsByTagName("head")[0].append(darkStyleLink);
+      }
+    </script>
   </head>
   <body>
       <nav class="navbar navbar-default" id="mainmenu">
@@ -76,7 +87,6 @@
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
     <script type="text/javascript" charset="utf-8" src="{{.URL.Parse "/js/main.js"}}"></script>
-
 
         {{block "js_footer" .}}{{end}}
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-	<title>Nyaa Pantsu - {{block "title" .}}{{ T "error_404" }}{{end}}</title>
+	  <title>Nyaa Pantsu - {{block "title" .}}{{ T "error_404" }}{{end}}</title>
     <link rel="icon" type="image/png" href="/img/favicon.png?v=3" />
 
     <!-- RSS Feed with Context -->
@@ -30,6 +30,18 @@
 
     <!-- Website CSS -->
     <link rel="stylesheet" id="style" href="{{.URL.Parse "/css/style.css"}}">
+    <script type="text/javascript">
+      // Night mode
+      var night = localStorage.getItem("night");
+      var darkStyleLink = document.createElement('link');
+      darkStyleLink.id = "style-dark";
+      darkStyleLink.rel = "stylesheet";
+      darkStyleLink.type = "text/css";
+      darkStyleLink.href = "/css/style-night.css"
+      if (night == "true") {
+          document.getElementsByTagName("head")[0].append(darkStyleLink);
+      }
+    </script>
   </head>
   <body>
       <nav class="navbar navbar-default" id="mainmenu">

--- a/templates/user/login.html
+++ b/templates/user/login.html
@@ -14,13 +14,13 @@
 					<div class="form-group">
 	                    <input type="text" name="username" id="username" class="form-control input-lg" autofocus="" placeholder="{{ T "email_address_or_username"}}">
        	            	{{ range (index $.FormErrors "username")}}
-						<p class="bg-danger">{{ . }}</p>
+						<p class="text-error">{{ . }}</p>
 						{{end}}
 					</div>
 					<div class="form-group">
 	                    <input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{ T "password"}}">
                			{{ range (index $.FormErrors "password")}}
-						<p class="bg-danger">{{ . }}</p>
+						<p class="text-error">{{ . }}</p>
 						{{end}}
 					</div>
 					<span class="button-checkbox">

--- a/templates/user/register.html
+++ b/templates/user/register.html
@@ -14,13 +14,13 @@
 				<div class="form-group">
 					<input type="text" name="username" id="display_name" class="form-control input-lg" placeholder="{{T "username" }}" tabindex="1" value="{{ .Username }}">
    							{{ range (index $.FormErrors "username")}}
-   							<p class="bg-danger">{{ . }}</p>
+   							<p class="text-error">{{ . }}</p>
    							{{end}}
 				</div>
 				<div class="form-group">
 					<input type="email" name="email" id="email" class="form-control input-lg" placeholder="{{T "email_address" }}" tabindex="2" value="{{ .Email }}">
    							{{ range (index $.FormErrors "email")}}
-   							<p class="bg-danger">{{ . }}</p>
+   							<p class="text-error">{{ . }}</p>
    							{{end}}
 				</div>
 				<div class="row">
@@ -28,7 +28,7 @@
 						<div class="form-group">
 							<input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{T "password" }}" tabindex="3" value="{{ .Password }}">
    							{{ range (index $.FormErrors "password")}}
-   							<p class="bg-danger">{{ . }}</p>
+   							<p class="text-error">{{ . }}</p>
    							{{end}}
    						</div>
 					</div>
@@ -36,7 +36,7 @@
 						<div class="form-group">
 							<input type="password" name="password_confirmation" id="password_confirmation" class="form-control input-lg" placeholder="{{T "confirm_password" }}" tabindex="4">
    							{{ range (index $.FormErrors "password_confirmation")}}
-   							<p class="bg-danger">{{ . }}</p>
+   							<p class="text-error">{{ . }}</p>
    							{{end}}
 						</div>
 					</div>
@@ -47,7 +47,7 @@
 							<button type="button" class="btn hidden" data-color="info" tabindex="5">{{T "i_agree" }}</button>
 	                        <input type="checkbox" name="t_and_c" id="t_and_c" value="1">
    							{{ range (index $.FormErrors "t_and_c")}}
-   							<p class="bg-danger">{{ . }}</p>
+   							<p class="text-error">{{ . }}</p>
    							{{end}}
 						</span>
 					</div>


### PR DESCRIPTION
Overrides bootstrap's default bg-danger color because it looks ugly, especially using the night theme.
Here's the old version: [https://my.mixtape.moe/hktvzt.png](https://my.mixtape.moe/hktvzt.png)
Here's the new version: [night](https://my.mixtape.moe/wsuhvc.png) and [normal](https://my.mixtape.moe/zyrjkv.png)

We can change the colors if any of you still find it ugly, as long as we don't make it default.