### PR TITLE
Move 'advanced' search into table headers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -202,6 +202,10 @@ div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:last-of-typ
 {
 	width: 12rem;
 }
+#mainmenu .navbar-form select.form-control#max
+{
+  width: 8rem;
+}
 .special-img 
 {
     position: relative;

--- a/router/templateFunctions.go
+++ b/router/templateFunctions.go
@@ -36,6 +36,24 @@ var FuncMap = template.FuncMap{
 		}
 		return "error"
 	},
+	"genSearchWithOrdering": func(currentUrl url.URL, sortBy string) template.URL {
+		values := currentUrl.Query()
+		order := false
+		if _, ok := values["order"]; ok {
+			order, _ = strconv.ParseBool(values["order"][0])
+			if values["sort"][0]==sortBy {
+				order=!order //Flip order by repeat-clicking
+			} else {
+				order=false //Default to descending when sorting by something new
+			}
+		}
+		values.Set("sort", sortBy)
+		values.Set("order", strconv.FormatBool(order))
+
+		currentUrl.RawQuery=values.Encode()
+		
+		return template.URL(currentUrl.String())
+	},
 	"genNav": func(nav Navigation, currentUrl *url.URL, pagesSelectable int) template.HTML {
 		var ret = ""
 		if (nav.TotalItem > 0) {

--- a/templates/_search.html
+++ b/templates/_search.html
@@ -31,24 +31,7 @@
     <option value="2" {{if eq .Search.Status 2}}selected{{end}}>{{T "trusted"}}</option>
     <option value="3" {{if eq .Search.Status 3}}selected{{end}}>A+</option>
   </select>
-  <input type="hidden" name="userID" value="{{ .Search.UserID }}">
-{{end}}
-{{define "search_advanced"}}
-  <select name="sort" class="form-control input-sm">
-    <option value="0" {{if eq .Search.Sort 0}}selected{{end}}>{{T "id"}}</option>
-    <option value="1" {{if eq .Search.Sort 1}}selected{{end}}>{{T "name"}}</option>
-    <option value="2" {{if eq .Search.Sort 2}}selected{{end}}>{{T "date"}}</option>
-    <option value="3" {{if eq .Search.Sort 3}}selected{{end}}>{{T "downloads"}}</option>
-    <option value="4" {{if eq .Search.Sort 4}}selected{{end}}>{{T "size"}}</option>
-    <option value="5" {{if eq .Search.Sort 4}}selected{{end}}>{{T "seeders"}}</option>
-    <option value="6" {{if eq .Search.Sort 4}}selected{{end}}>{{T "leechers"}}</option>
-    <option value="7" {{if eq .Search.Sort 4}}selected{{end}}>{{T "completed"}}</option>
-  </select>
-  <select name="order" class="form-control input-sm">
-    <option value="false" {{if eq .Search.Order false}}selected{{end}}>{{T "descending"}}</option>
-    <option value="true" {{if eq .Search.Order true}}selected{{end}}>{{T "ascending"}}</option>
-  </select>
-  <select name="max" class="form-control input-sm">
+  <select id="max" name="max" class="form-control input-sm">
     <option value="5" {{if eq .Navigation.MaxItemPerPage 5}}selected{{end}}>5</option>
     <option value="10" {{if eq .Navigation.MaxItemPerPage 10}}selected{{end}}>10</option>
     <option value="15" {{if eq .Navigation.MaxItemPerPage 15}}selected{{end}}>15</option>
@@ -65,6 +48,7 @@
     <option value="200" {{if eq .Navigation.MaxItemPerPage 200}}selected{{end}}>200</option>
     <option value="300" {{if eq .Navigation.MaxItemPerPage 300}}selected{{end}}>300</option>
   </select>
+  <input type="hidden" name="userID" value="{{ .Search.UserID }}">
 {{end}}
 
 {{define "search_button"}}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,7 +1,7 @@
 {{define "title"}}{{T "home"}}{{end}}
 {{define "contclass"}}cont-home{{end}}
 {{define "content"}}
-	<div class="blockBody">
+  <div class="blockBody">
       <ul class="list-inline" aria-label="Page navigation">
           <li><img id="mascot" src="/img/renchon.png" /></li>
           <li style="padding-top: 7%;" class="pull-right"><ul class="pagination">
@@ -13,10 +13,16 @@
           <table class="table custom-table-hover">
           <tr>
               <th class="col-xs-1 hidden-xs">{{T "category"}}</th>
-              <th class="col-xs-8">{{T "name"}}</th>
-              <th class="col-xs-1 hidden-xs">{{T "S"}} / {{T "L"}} / {{T "D"}}</th>
-              <th class="col-xs-1 hidden-xs">{{T "date"}}</th>
-              <th class="col-xs-1 hidden-xs">{{T "size"}}</th>
+              <th class="col-xs-8">
+                <a href="{{ genSearchWithOrdering .URL "1" }}">{{T "name"}}</a>
+              </th>
+              <th class="col-xs-1 hidden-xs">
+                <a href="{{ genSearchWithOrdering .URL "4" }}">{{T "S"}}</a> / 
+                <a href="{{ genSearchWithOrdering .URL "4" }}">{{T "L"}}</a> / 
+                <a href="{{ genSearchWithOrdering .URL "3" }}">{{T "D"}}</a>
+              </th>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "2" }}">{{T "date"}}</th></a>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "4" }}">{{T "size"}}</a></th>
               <th class="col-xs-1 hidden-xs">{{T "links"}}</th>
           </tr>
           {{ range .ListTorrents}}

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,21 +72,6 @@
       <div style="padding-top: 10rem"></div>
 
       <div class="container {{block "contclass" .}}generic{{end}}" id="container">
-      {{if not .Search.HideAdvancedSearch}}
-      <div class="blockBody" style="text-align:center">
-        <a href="#advanced-search" data-toggle="collapse">{{T "advanced_search"}}</a><br />
-        <form id="advanced-search" class="navbar-form collapse" role="search" action="/search" method="get">
-          <div class="form-group">
-            {{block "search_common" .}}{{end}}
-            {{block "search_advanced" .}}{{end}}
-            {{block "search_button" .}}{{end}}
-          </div>
-        </form>
-        <div style="clear:both"></div>
-      </div>
-      <div style="margin:0.5em"></div>
-      {{end}}
-
         {{block "content" .}}{{T "nothing_here"}}{{end}}
       </div>
 
@@ -95,6 +80,7 @@
       <footer>
       Powered by NyaaPantsu
       </footer>
+
 
       {{if eq .User.ID 0}}
 	  <form method="POST" action="{{ .URL.Parse "/language" }}" id="bottom_language_selector_form">


### PR DESCRIPTION
See comment at bottom before merging.

The so-called 'advanced' search is actually just a duplication of elements elsewhere on the page, except pagination which isn't even really a search option (from user's perspective). See [diagram](http://puu.sh/vOklD/9d166d6eaf.png).

I'm moving the sorting options into the header of the table, so it can be sorted the same way as every other not-terrible HTML table ever. (i.e., click header to sort by that, click again to reverse order)

To Do:
- DELET advanced search
- Handle blank query string properly
- Up/Down arrows to show what we are sorting by? (see also: the other nyaa)
- Determine how this relates to torrent list on user profile page.
- Rebase