### PR TITLE
Fix registration view tab order

### DIFF
--- a/templates/_captcha.html
+++ b/templates/_captcha.html
@@ -5,7 +5,7 @@
 		<label for="solution">Captcha</label>
 		<input type="text" name="captchaID" value="{{.CaptchaID}}" hidden>
 		<img src="/captcha/{{.CaptchaID}}.png">
-		<input type="text" name="solution" class="form-control" placeholder="Captcha" autocomplete="off" required>
+		<input type="text" name="solution" id="solution" class="form-control" placeholder="Captcha" autocomplete="off" required>
 	</div>
 	{{end}}
 {{end}}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -7,7 +7,7 @@
 
       <div class="form-group">
       <label for="name">{{T "name"}}</label>
-          <input type="text" name="name" class="form-control" placeholder="File Name" value="{{.Name}}" required>
+          <input type="text" name="name" id="name" class="form-control" placeholder="File Name" value="{{.Name}}" autofocus required>
       </div>
       <div class="form-group">
           <label for="torrent">{{T "torrent_file"}}</label>
@@ -16,12 +16,12 @@
       </div>
       <div class="form-group">
           <label for="magnet">{{T "magnet_link"}}</label>
-          <input type="text" name="magnet" class="form-control"
+          <input  type="text" name="magnet" id="magnet" class="form-control"
           style="width:60rem" placeholder="{{T "magnet_link"}}" value="{{.Magnet}}">
       </div>
       <div class="form-group">
           <label for="c">{{T "category"}}</label>
-          <select name="c" class="form-control input-sm" required>
+          <select name="c" id="c" class="form-control input-sm" required>
               <option value="">{{T "select_a_torrent_category"}}</option>
               <option value="3_12" {{if eq .Category "3_12"}}selected{{end}}>{{T "anime_amv"}}</option>
               <option value="3_5" {{if eq .Category "3_5"}}selected{{end}}>{{T "anime_english_translated"}}</option>
@@ -43,14 +43,14 @@
           </select>
       </div>
       <div class="form-group">
-      	  <input type="checkbox" name="remake">
+      	  <input type="checkbox" name="remake" id="remake" >
           <label for="remake">{{T "mark_as_remake"}}</label>
       </div>
 
       <div class="form-group">
           <label for="desc">{{T "torrent_description"}}</label>
           <p class="help-block">{{T "description_markdown_notice"}}</p>
-          <textarea name="desc" class="form-control" rows="10">{{.Description}}</textarea>
+          <textarea name="desc" id="desc" class="form-control" rows="10">{{.Description}}</textarea>
       </div>
 
       {{block "captcha" .}}{{end}}

--- a/templates/user/login.html
+++ b/templates/user/login.html
@@ -12,7 +12,7 @@
 	   					<div class="alert alert-danger">{{ . }}</div>
 	   				{{end}}
 					<div class="form-group">
-	                    <input type="text" name="username" id="username" class="form-control input-lg" autofocus="" placeholder="{{ T "email_address_or_username"}}">
+	                    <input type="text" name="username" id="username" class="form-control input-lg" autofocus placeholder="{{ T "email_address_or_username"}}">
        	            	{{ range (index $.FormErrors "username")}}
 						<p class="text-error">{{ . }}</p>
 						{{end}}

--- a/templates/user/register.html
+++ b/templates/user/register.html
@@ -12,13 +12,13 @@
    					<div class="alert alert-danger">{{ . }}</div>
    				{{end}}
 				<div class="form-group">
-					<input type="text" name="username" id="display_name" class="form-control input-lg" placeholder="{{T "username" }}" tabindex="1" value="{{ .Username }}">
+					<input type="text" name="username" id="display_name" class="form-control input-lg" placeholder="{{T "username" }}" value="{{ .Username }}" autofocus>
    							{{ range (index $.FormErrors "username")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
 				</div>
 				<div class="form-group">
-					<input type="email" name="email" id="email" class="form-control input-lg" placeholder="{{T "email_address" }}" tabindex="2" value="{{ .Email }}">
+					<input type="email" name="email" id="email" class="form-control input-lg" placeholder="{{T "email_address" }}" value="{{ .Email }}">
    							{{ range (index $.FormErrors "email")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
@@ -26,7 +26,7 @@
 				<div class="row">
 					<div class="col-xs-12 col-sm-6 col-md-6">
 						<div class="form-group">
-							<input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{T "password" }}" tabindex="3" value="{{ .Password }}">
+							<input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{T "password" }}" value="{{ .Password }}">
    							{{ range (index $.FormErrors "password")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
@@ -34,7 +34,7 @@
 					</div>
 					<div class="col-xs-12 col-sm-6 col-md-6">
 						<div class="form-group">
-							<input type="password" name="password_confirmation" id="password_confirmation" class="form-control input-lg" placeholder="{{T "confirm_password" }}" tabindex="4">
+							<input type="password" name="password_confirmation" id="password_confirmation" class="form-control input-lg" placeholder="{{T "confirm_password" }}">
    							{{ range (index $.FormErrors "password_confirmation")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
@@ -44,7 +44,7 @@
 				<div class="row">
 					<div class="col-xs-4 col-sm-3 col-md-3">
 						<span class="button-checkbox">
-							<button type="button" class="btn hidden" data-color="info" tabindex="5">{{T "i_agree" }}</button>
+							<button type="button" class="btn hidden" data-color="info">{{T "i_agree" }}</button>
 	                        <input type="checkbox" name="t_and_c" id="t_and_c" value="1">
    							{{ range (index $.FormErrors "t_and_c")}}
    							<p class="text-error">{{ . }}</p>
@@ -60,7 +60,7 @@
 
 				<hr class="colorgraph">
 				<div class="row">
-					<div class="col-xs-12 col-md-6"><input type="submit" value="{{T "register" }}" class="btn btn-primary btn-block btn-lg" tabindex="7"></div>
+					<div class="col-xs-12 col-md-6"><input type="submit" value="{{T "register" }}" class="btn btn-primary btn-block btn-lg"></div>
 					<div class="col-xs-12 col-md-6">or <a href="{{ genRoute "user_login" }}" class="">{{T "signin" }}</a></div>
 				</div>
 			</form>


### PR DESCRIPTION
Since the captcha uses the default tab order it was getting skipped
by the registration form.

- Add autofocus to the registration and upload view
- Add id attribute to input elements that have a label