### PR TITLE
Add filesize fetcher mode (need SOMEONE for testing)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,11 @@ type Config struct {
 	Search SearchConfig `json:"search"`
 	// optional i2p configuration
 	I2P *I2PConfig `json:"i2p"`
+	// filesize fetcher config
+	FilesizeFetcher FilesizeFetcherConfig `json:"filesize_fetcher"`
 }
 
-var Defaults = Config{"localhost", 9999, "sqlite3", "./nyaa.db?cache_size=50", "default", DefaultScraperConfig, DefaultCacheConfig, DefaultSearchConfig, nil}
+var Defaults = Config{"localhost", 9999, "sqlite3", "./nyaa.db?cache_size=50", "default", DefaultScraperConfig, DefaultCacheConfig, DefaultSearchConfig, nil, DefaultFilesizeFetcherConfig}
 
 var allowedDatabaseTypes = map[string]bool{
 	"sqlite3":  true,
@@ -57,6 +59,7 @@ func New() *Config {
 	config.DBLogMode = Defaults.DBLogMode
 	config.Scrape = Defaults.Scrape
 	config.Cache = Defaults.Cache
+	config.FilesizeFetcher = Defaults.FilesizeFetcher
 	return &config
 }
 

--- a/config/filesizeFetcher.go
+++ b/config/filesizeFetcher.go
@@ -1,0 +1,16 @@
+package config
+
+type FilesizeFetcherConfig struct {
+	QueueSize      int `json:"queue_size"`
+	Timeout        int `json:"timeout"`
+	MaxDays        int `json:"max_days"`
+	WakeUpInterval int `json:"wake_up_interval"`
+}
+
+var DefaultFilesizeFetcherConfig = FilesizeFetcherConfig{
+	QueueSize: 10,
+	Timeout: 120, // 2 min
+	MaxDays: 90,
+	WakeUpInterval: 300, // 5 min
+}
+

--- a/db/gorm.go
+++ b/db/gorm.go
@@ -58,7 +58,7 @@ func GormInit(conf *config.Config, logger Logger) (*gorm.DB, error) {
 	if db.Error != nil {
 		return db, db.Error
 	}
-	db.AutoMigrate(&model.Torrent{}, &model.TorrentReport{})
+	db.AutoMigrate(&model.Torrent{}, &model.TorrentReport{}, &model.File{})
 	if db.Error != nil {
 		return db, db.Error
 	}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ewhal/nyaa/network"
 	"github.com/ewhal/nyaa/router"
 	"github.com/ewhal/nyaa/service/scraper"
+	"github.com/ewhal/nyaa/service/torrent/filesizeFetcher"
 	"github.com/ewhal/nyaa/util/log"
 	"github.com/ewhal/nyaa/util/search"
 	"github.com/ewhal/nyaa/util/signals"
@@ -94,6 +95,18 @@ func RunScraper(conf *config.Config) {
 	scraper.Wait()
 }
 
+// RunFilesizeFetcher runs the database filesize fetcher main loop
+func RunFilesizeFetcher(conf *config.Config) {
+	fetcher, err := filesizeFetcher.New(&conf.FilesizeFetcher)
+	if err != nil {
+		log.Fatalf("failed to start fetcher, %s", err)
+		return
+	}
+
+	signals.RegisterCloser(fetcher)
+	fetcher.Run()
+}
+
 func main() {
 	conf := config.New()
 	processFlags := conf.BindFlags()
@@ -142,6 +155,8 @@ func main() {
 			RunScraper(conf)
 		} else if *mode == "webapp" {
 			RunServer(conf)
+		} else if *mode == "filesize_fetcher" {
+			RunFilesizeFetcher(conf)
 		} else {
 			log.Fatalf("invalid runtime mode: %s", *mode)
 		}

--- a/main.go
+++ b/main.go
@@ -104,14 +104,15 @@ func RunFilesizeFetcher(conf *config.Config) {
 	}
 
 	signals.RegisterCloser(fetcher)
-	fetcher.Run()
+	fetcher.RunAsync()
+	fetcher.Wait()
 }
 
 func main() {
 	conf := config.New()
 	processFlags := conf.BindFlags()
 	defaults := flag.Bool("print-defaults", false, "print the default configuration file on stdout")
-	mode := flag.String("mode", "webapp", "which mode to run daemon in, either webapp or scraper")
+	mode := flag.String("mode", "webapp", "which mode to run daemon in, either webapp, scraper or filesize_fetcher")
 	flag.Float64Var(&conf.Cache.Size, "c", config.DefaultCacheSize, "size of the search cache in MB")
 
 	flag.Parse()

--- a/model/file.go
+++ b/model/file.go
@@ -1,0 +1,16 @@
+package model
+
+type File struct {
+	ID        uint   `gorm:"column:file_id;primary_key"`
+	TorrentID uint   `gorm:"column:torrent_id"`
+	Path      string `gorm:"column:path"`
+	Filesize      int64  `gorm:"column:filesize"`
+
+	Torrent *Torrent `gorm:"AssociationForeignKey:TorrentID;ForeignKey:torrent_id"`
+}
+
+// Returns the total size of memory allocated for this struct
+func (f File) Size() int {
+	return (1 + len(f.Path) + 2) * 8;
+}
+

--- a/model/torrent.go
+++ b/model/torrent.go
@@ -44,6 +44,7 @@ type Torrent struct {
 	Leechers   uint32    `gorm:"column:leechers"`
 	Completed  uint32    `gorm:"column:completed"`
 	LastScrape time.Time `gorm:"column:last_scrape"`
+	FileList   []File    `gorm:"ForeignKey:torrent_id"`
 }
 
 // Returns the total size of memory recursively allocated for this struct
@@ -88,6 +89,11 @@ type CommentJSON struct {
 	Date     time.Time     `json:"date"`
 }
 
+type FileJSON struct {
+	Path  string `json:"path"`
+	Length int64 `json:"length"`
+}
+
 type TorrentJSON struct {
 	ID           string        `json:"id"`
 	Name         string        `json:"name"`
@@ -110,6 +116,7 @@ type TorrentJSON struct {
 	Leechers     uint32        `json:"leechers"`
 	Completed    uint32        `json:"completed"`
 	LastScrape   time.Time     `json:"last_scrape"`
+	FileList     []File        `json:"file_list"`
 }
 
 // ToJSON converts a model.Torrent to its equivalent JSON structure
@@ -155,6 +162,7 @@ func (t *Torrent) ToJSON() TorrentJSON {
 		Seeders:      t.Seeders,
 		Completed:    t.Completed,
 		LastScrape:   t.LastScrape,
+		FileList:     t.FileList,
 	}
 
 	return res

--- a/service/service.go
+++ b/service/service.go
@@ -5,7 +5,7 @@ type WhereParams struct {
 	Params     []interface{}
 }
 
-func CreateWhereParams(conditions string, params ...string) WhereParams {
+func CreateWhereParams(conditions string, params ...interface{}) WhereParams {
 	whereParams := WhereParams{
 		Conditions: conditions,
 		Params:     make([]interface{}, len(params)),

--- a/service/torrent/filesizeFetcher/filesizeFetcher.go
+++ b/service/torrent/filesizeFetcher/filesizeFetcher.go
@@ -82,7 +82,7 @@ func (fetcher *FilesizeFetcher) removeFromQueue(op *FetchOperation) bool {
 func (fetcher *FilesizeFetcher) gotResult(r Result) {
 	updatedSuccessfully := false
 	if r.err != nil {
-		log.Infof("Failed to get torrent filesize (TID: %d), err ", r.operation.torrent.ID)
+		log.Infof("Failed to get torrent filesize (TID: %d), err %v", r.operation.torrent.ID, r.err)
 	} else if r.info.Length == 0 {
 		log.Infof("Got length 0 for torrent TID: %d. Possible bug?", r.operation.torrent.ID)
 	} else {

--- a/service/torrent/filesizeFetcher/filesizeFetcher.go
+++ b/service/torrent/filesizeFetcher/filesizeFetcher.go
@@ -29,11 +29,11 @@ func New(fetcherConfig *config.FilesizeFetcherConfig) (fetcher *FilesizeFetcher,
 	client, err := torrent.NewClient(nil)
 	fetcher = &FilesizeFetcher{
 		torrentClient:    client,
-		results:          make(chan Result),
+		results:          make(chan Result, fetcherConfig.QueueSize),
 		queueSize:        fetcherConfig.QueueSize,
 		timeout:          fetcherConfig.Timeout,
 		maxDays:          fetcherConfig.MaxDays,
-		done:             make(chan int),
+		done:             make(chan int, 1),
 		failedOperations: make(map[uint]struct{}),
 		wakeUp:           time.NewTicker(time.Second * time.Duration(fetcherConfig.WakeUpInterval)),
 	}

--- a/service/torrent/filesizeFetcher/operation.go
+++ b/service/torrent/filesizeFetcher/operation.go
@@ -1,0 +1,58 @@
+package filesizeFetcher;
+
+import (
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/ewhal/nyaa/config"
+	"github.com/ewhal/nyaa/model"
+	"github.com/ewhal/nyaa/util"
+	"errors"
+	"time"
+	"strings"
+)
+
+type FetchOperation struct {
+	fetcher  *FilesizeFetcher
+	torrent  model.Torrent
+	done     chan int
+}
+
+type Result struct {
+	operation *FetchOperation
+	err       error
+	info      *metainfo.Info
+}
+
+func NewFetchOperation(fetcher *FilesizeFetcher, dbEntry model.Torrent) (op *FetchOperation) {
+	op = &FetchOperation{
+		fetcher:  fetcher,
+		torrent:  dbEntry,
+		done:     make(chan int),
+	}
+	return
+}
+
+// Should be started from a goroutine somewhere
+func (op *FetchOperation) Start(out chan Result) {
+	magnet := util.InfoHashToMagnet(strings.TrimSpace(op.torrent.Hash), op.torrent.Name, config.Trackers...)
+	downloadingTorrent, err := op.fetcher.torrentClient.AddMagnet(magnet)
+	if err != nil {
+		out <- Result{op, err, nil}
+		return
+	}
+
+	timeoutTicker := time.NewTicker(time.Second * time.Duration(op.fetcher.timeout))
+	select {
+	case <-downloadingTorrent.GotInfo():
+		downloadingTorrent.Drop()
+		out <- Result{op, nil, downloadingTorrent.Info()}
+		return
+	case <-timeoutTicker.C:
+		downloadingTorrent.Drop()
+		out <- Result{op, errors.New("Timeout"), nil}
+		return
+	case <-op.done:
+		downloadingTorrent.Drop()
+		return
+	}
+}
+

--- a/service/torrent/filesizeFetcher/operation.go
+++ b/service/torrent/filesizeFetcher/operation.go
@@ -26,7 +26,7 @@ func NewFetchOperation(fetcher *FilesizeFetcher, dbEntry model.Torrent) (op *Fet
 	op = &FetchOperation{
 		fetcher:  fetcher,
 		torrent:  dbEntry,
-		done:     make(chan int),
+		done:     make(chan int, 1),
 	}
 	return
 }

--- a/service/torrent/filesizeFetcher/operation_test.go
+++ b/service/torrent/filesizeFetcher/operation_test.go
@@ -1,0 +1,45 @@
+package filesizeFetcher;
+
+import (
+	"testing"
+
+	"github.com/anacrolix/torrent"
+	"github.com/ewhal/nyaa/model"
+)
+
+func TestInvalidHash(t *testing.T) {
+	client, err := torrent.NewClient(nil)
+	if err != nil {
+		t.Skipf("Failed to create client, with err %v. Skipping.", err)
+	}
+
+	fetcher := &FilesizeFetcher{
+		timeout: 5,
+		torrentClient: client,
+		results: make(chan Result, 1),
+	}
+
+	dbEntry := model.Torrent{
+		Hash: "INVALID",
+		Name: "Invalid",
+	}
+
+	op := NewFetchOperation(fetcher, dbEntry)
+	fetcher.wg.Add(1)
+	op.Start(fetcher.results)
+
+	var res Result
+	select {
+	case res = <-fetcher.results:
+		break
+	default:
+		t.Fatal("No result in channel, should have one")
+	}
+
+	if res.err == nil {
+		t.Fatal("Got no error, should have got invalid magnet")
+	}
+
+	t.Logf("Got error %s, shouldn't be timeout", res.err)
+}
+


### PR DESCRIPTION
Uses a torrent client to fetch the filesize of the torrents with `filesize IS NULL` or `filesize = 0` on the DB.

Seems to work, but needs to be tested with a more recent DB (especially with the HorribleSubs scraped one)