### PR TITLE
Fix i18n file error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	DBType string `json:"db_type"`
 	// DBParams will be directly passed to Gorm, and its internal
 	// structure depends on the dialect for each db type
-	DBParams string `json:"db_params"`
+	DBParams  string `json:"db_params"`
 	DBLogMode string `json:"db_logmode"`
 	// tracker scraper config (required)
 	Scrape ScraperConfig `json:"scraper"`
@@ -29,11 +29,13 @@ type Config struct {
 	Cache CacheConfig `json:"cache"`
 	// search config
 	Search SearchConfig `json:"search"`
+	// internationalization config
+	I18n I18nConfig `json:"i18n"`
 	// optional i2p configuration
 	I2P *I2PConfig `json:"i2p"`
 }
 
-var Defaults = Config{"localhost", 9999, "sqlite3", "./nyaa.db?cache_size=50", "default", DefaultScraperConfig, DefaultCacheConfig, DefaultSearchConfig, nil}
+var Defaults = Config{"localhost", 9999, "sqlite3", "./nyaa.db?cache_size=50", "default", DefaultScraperConfig, DefaultCacheConfig, DefaultSearchConfig, DefaultI18nConfig, nil}
 
 var allowedDatabaseTypes = map[string]bool{
 	"sqlite3":  true,
@@ -57,6 +59,7 @@ func New() *Config {
 	config.DBLogMode = Defaults.DBLogMode
 	config.Scrape = Defaults.Scrape
 	config.Cache = Defaults.Cache
+	config.I18n = Defaults.I18n
 	return &config
 }
 

--- a/config/i18n.go
+++ b/config/i18n.go
@@ -1,0 +1,11 @@
+package config
+
+type I18nConfig struct {
+	TranslationsDirectory string `json:"translations_directory"`
+	DefaultLanguage       string `json:"default_language"`
+}
+
+var DefaultI18nConfig = I18nConfig{
+	TranslationsDirectory: "translations",
+	DefaultLanguage:       "en-us", // TODO: Remove refs to "en-us" from the code and templates
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/ewhal/nyaa/cache"
@@ -15,22 +14,11 @@ import (
 	"github.com/ewhal/nyaa/network"
 	"github.com/ewhal/nyaa/router"
 	"github.com/ewhal/nyaa/service/scraper"
+	"github.com/ewhal/nyaa/util/languages"
 	"github.com/ewhal/nyaa/util/log"
 	"github.com/ewhal/nyaa/util/search"
 	"github.com/ewhal/nyaa/util/signals"
-	"github.com/nicksnyder/go-i18n/i18n"
 )
-
-func initI18N() {
-	/* Initialize the languages translation */
-	i18n.MustLoadTranslationFile("translations/en-us.all.json")
-	paths, err := filepath.Glob("translations/*.json")
-	if err == nil {
-		for _, path := range paths {
-			i18n.LoadTranslationFile(path)
-		}
-	}
-}
 
 // RunServer runs webapp mainloop
 func RunServer(conf *config.Config) {
@@ -122,7 +110,10 @@ func main() {
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		initI18N()
+		err = languages.InitI18n(conf.I18n)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
 		err = cache.Configure(&conf.Cache)
 		if err != nil {
 			log.Fatal(err.Error())

--- a/translations/es-es.all.json
+++ b/translations/es-es.all.json
@@ -352,7 +352,7 @@
     "translation": "Todas las Categorías"
   },
   {
-    "id:": "select_a_torrent_category",
+    "id": "select_a_torrent_category",
     "translation": "Selecciona una Categoría para el Torrent"
   },
   {

--- a/translations/zh-cn.all.json
+++ b/translations/zh-cn.all.json
@@ -352,7 +352,7 @@
     "translation": "所有分类"
   },
   {
-    "id:": "select_a_torrent_category",
+    "id": "select_a_torrent_category",
     "translation": "请选择种子分类"
   },
   {

--- a/util/languages/translation_test.go
+++ b/util/languages/translation_test.go
@@ -1,0 +1,18 @@
+package languages
+
+import (
+	"path"
+	"testing"
+
+	"github.com/ewhal/nyaa/config"
+)
+
+func TestInitI18n(t *testing.T) {
+	conf := config.DefaultI18nConfig
+	conf.TranslationsDirectory = path.Join("..", "..", conf.TranslationsDirectory)
+
+	err := InitI18n(conf)
+	if err != nil {
+		t.Errorf("failed to initialize language translations: %v", err)
+	}
+}


### PR DESCRIPTION
- Fixed an error in the spanish and chinese translation file
- Refactored reading the translation files
  Moved the code out of main.go and instead of ignoring
  errors in the non-default language files
  the error will now be returned and the remaining files will
  not be loaded.
  **I could revert this to the previous logic (load all files) and then return an aggregated error** Suggestions?
- Added a unit test to check if all translation files are valid
- Added an i18n config to specify the translations dir and the
  default language