### PR TITLE
Make table header sorting work on home page

### DIFF
--- a/router/templateFunctions.go
+++ b/router/templateFunctions.go
@@ -50,9 +50,10 @@ var FuncMap = template.FuncMap{
 		values.Set("sort", sortBy)
 		values.Set("order", strconv.FormatBool(order))
 
-		currentUrl.RawQuery=values.Encode()
+		url, _ := Router.Get("search").URL()
+		url.RawQuery=values.Encode()
 		
-		return template.URL(currentUrl.String())
+		return template.URL(url.String())
 	},
 	"genNav": func(nav Navigation, currentUrl *url.URL, pagesSelectable int) template.HTML {
 		var ret = ""


### PR DESCRIPTION
by making the links always point to /search/