### PR TITLE
Sorting arrows on table headers

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -136,21 +136,23 @@ tr.torrent-info td.date {
   border-top: 1px solid #ddd;
 }
 
+th a:hover {
+  text-decoration: none;
+}
+
+.sortarrowleft {
+  letter-spacing: -0.6rem;
+}
+
+.sortarrowdim {
+  opacity: 0.25;
+}
+
 div.container div.blockBody:nth-of-type(2) table{table-layout:fixed;}
 div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:first-of-type, div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type(5){width:10%;}
 div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type(3){width:15%;}
 div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type(4){width:19%;}
 div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:last-of-type{width:6%;}
-
-a.sortnone::after {
-  content: "↕";
-}
-a.sortasc::after {
-  content: "↑";
-}
-a.sortdesc::after {
-  content: "↓";
-}
 
 /* Mobile-friendly main table */
 @media only screen and (max-width: 700px) {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -142,6 +142,16 @@ div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type
 div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:nth-of-type(4){width:19%;}
 div.container div.blockBody:nth-of-type(2) table tr:first-of-type th:last-of-type{width:6%;}
 
+a.sortnone::after {
+  content: "↕";
+}
+a.sortasc::after {
+  content: "↑";
+}
+a.sortdesc::after {
+  content: "↓";
+}
+
 /* Mobile-friendly main table */
 @media only screen and (max-width: 700px) {
   table, thead, tbody, tr {

--- a/router/templateFunctions.go
+++ b/router/templateFunctions.go
@@ -55,21 +55,24 @@ var FuncMap = template.FuncMap{
 
 		return template.URL(url.String())
 	},
-	"genSortClass": func(currentUrl url.URL, sortBy string) string {
+	"genSortArrows": func(currentUrl url.URL, sortBy string) template.HTML {
 		values := currentUrl.Query()
-		class := "sortnone"
+		leftclass := "sortarrowdim"
+		rightclass := "sortarrowdim"
 
 		if _, ok := values["order"]; ok {
 			if values["sort"][0] == sortBy {
 				if values["order"][0] == "true" {
-					class="sortasc"
+					rightclass = ""
 				} else {
-					class="sortdesc"
+					leftclass = ""
 				}
 			}
 		}
 
-		return class
+		arrows := "<span class=\"sortarrowleft "+leftclass+"\">▼</span><span class=\""+rightclass+"\">▲</span>"
+
+		return template.HTML(arrows)
 	},
 	"genNav": func(nav Navigation, currentUrl *url.URL, pagesSelectable int) template.HTML {
 		var ret = ""

--- a/router/templateFunctions.go
+++ b/router/templateFunctions.go
@@ -55,6 +55,22 @@ var FuncMap = template.FuncMap{
 
 		return template.URL(url.String())
 	},
+	"genSortClass": func(currentUrl url.URL, sortBy string) string {
+		values := currentUrl.Query()
+		class := "sortnone"
+
+		if _, ok := values["order"]; ok {
+			if values["sort"][0] == sortBy {
+				if values["order"][0] == "true" {
+					class="sortasc"
+				} else {
+					class="sortdesc"
+				}
+			}
+		}
+
+		return class
+	},
 	"genNav": func(nav Navigation, currentUrl *url.URL, pagesSelectable int) template.HTML {
 		var ret = ""
 		if nav.TotalItem > 0 {

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,16 +13,14 @@
           <table class="table custom-table-hover">
           <tr>
               <th class="col-xs-1 hidden-xs">{{T "category"}}</th>
-              <th class="col-xs-8">
-                <a href="{{ genSearchWithOrdering .URL "1" }}" class="{{ genSortClass .URL "1"}}">{{T "name"}}</a>
+              <th class="col-xs-12">
+                <a href="{{ genSearchWithOrdering .URL "1" }}">{{T "name"}}{{ genSortArrows .URL "1" }}</a>
               </th>
-              <th class="col-xs-1 hidden-xs">
-                <a href="{{ genSearchWithOrdering .URL "5" }}" class="{{ genSortClass .URL "5"}}">{{T "S"}}</a> / 
-                <a href="{{ genSearchWithOrdering .URL "6" }}" class="{{ genSortClass .URL "6"}}">{{T "L"}}</a> / 
-                <a href="{{ genSearchWithOrdering .URL "7" }}" class="{{ genSortClass .URL "7"}}">{{T "D"}}</a>
-              </th>
-              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "2" }}" class="{{ genSortClass .URL "2"}}">{{T "date"}}</th></a>
-              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "4" }}" class="{{ genSortClass .URL "4"}}">{{T "size"}}</a></th>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "5" }}">{{T "S"}}{{ genSortArrows .URL "5" }}</a></th>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "6" }}">{{T "L"}}{{ genSortArrows .URL "6" }}</a></th>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "7" }}">{{T "D"}}{{ genSortArrows .URL "7" }}</a></th>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "2" }}">{{T "date"}}{{ genSortArrows .URL "2" }}</th></a>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "4" }}">{{T "size"}}{{ genSortArrows .URL "4" }}</a></th>
               <th class="col-xs-1 hidden-xs">{{T "links"}}</th>
           </tr>
           {{ range .ListTorrents}}
@@ -41,7 +39,9 @@
                       {{.Name}}
                   </a>
               </td>
-              <td class="hidden-xs"><b class="text-success">{{.Seeders}}</b> / <b class="text-danger">{{.Leechers}}</b> / {{.Completed}}</td>
+              <td class="hidden-xs"><b class="text-success">{{.Seeders}}</b></td>
+              <td class="hidden-xs"><b class="text-danger">{{.Leechers}}</b></td>
+              <td class="hidden-xs">{{.Completed}}</td>
               <td class="hidden-xs date date-short">{{.Date}}</td>
               <td class="hidden-xs filesize">{{.Filesize}}</td>
               <td class="hidden-xs">

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,15 +14,15 @@
           <tr>
               <th class="col-xs-1 hidden-xs">{{T "category"}}</th>
               <th class="col-xs-8">
-                <a href="{{ genSearchWithOrdering .URL "1" }}">{{T "name"}}</a>
+                <a href="{{ genSearchWithOrdering .URL "1" }}" class="{{ genSortClass .URL "1"}}">{{T "name"}}</a>
               </th>
               <th class="col-xs-1 hidden-xs">
-                <a href="{{ genSearchWithOrdering .URL "5" }}">{{T "S"}}</a> / 
-                <a href="{{ genSearchWithOrdering .URL "6" }}">{{T "L"}}</a> / 
-                <a href="{{ genSearchWithOrdering .URL "7" }}">{{T "D"}}</a>
+                <a href="{{ genSearchWithOrdering .URL "5" }}" class="{{ genSortClass .URL "5"}}">{{T "S"}}</a> / 
+                <a href="{{ genSearchWithOrdering .URL "6" }}" class="{{ genSortClass .URL "6"}}">{{T "L"}}</a> / 
+                <a href="{{ genSearchWithOrdering .URL "7" }}" class="{{ genSortClass .URL "7"}}">{{T "D"}}</a>
               </th>
-              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "2" }}">{{T "date"}}</th></a>
-              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "4" }}">{{T "size"}}</a></th>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "2" }}" class="{{ genSortClass .URL "2"}}">{{T "date"}}</th></a>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "4" }}" class="{{ genSortClass .URL "4"}}">{{T "size"}}</a></th>
               <th class="col-xs-1 hidden-xs">{{T "links"}}</th>
           </tr>
           {{ range .ListTorrents}}


### PR DESCRIPTION
Sorting arrows are in place but do not really fit with the current layout.

[http://puu.sh/vPZ22/422ab1ef6d.png](http://puu.sh/vPZ22/422ab1ef6d.png)

See [https://github.com/ewhal/nyaa/issues/484](https://github.com/ewhal/nyaa/issues/484)