### PR TITLE
Replace 'en-us' literals with the default language

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,12 +33,11 @@ type Config struct {
 	I2P *I2PConfig `json:"i2p"`
 	// filesize fetcher config
 	FilesizeFetcher FilesizeFetcherConfig `json:"filesize_fetcher"`
-  // internationalization config
+	// internationalization config
 	I18n I18nConfig `json:"i18n"`
 }
 
 var Defaults = Config{"localhost", 9999, "sqlite3", "./nyaa.db?cache_size=50", "default", DefaultScraperConfig, DefaultCacheConfig, DefaultSearchConfig, nil, DefaultFilesizeFetcherConfig, DefaultI18nConfig}
-
 
 var allowedDatabaseTypes = map[string]bool{
 	"sqlite3":  true,

--- a/config/i18n.go
+++ b/config/i18n.go
@@ -7,5 +7,5 @@ type I18nConfig struct {
 
 var DefaultI18nConfig = I18nConfig{
 	TranslationsDirectory: "translations",
-	DefaultLanguage:       "en-us", // TODO: Remove refs to "en-us" from the code and templates
+	DefaultLanguage:       "en-us",
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ewhal/nyaa/router"
 	"github.com/ewhal/nyaa/service/scraper"
 	"github.com/ewhal/nyaa/service/torrent/filesizeFetcher"
+	"github.com/ewhal/nyaa/service/user"
 	"github.com/ewhal/nyaa/util/languages"
 	"github.com/ewhal/nyaa/util/log"
 	"github.com/ewhal/nyaa/util/search"
@@ -124,7 +125,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		err = languages.InitI18n(conf.I18n)
+		err = languages.InitI18n(conf.I18n, userService.NewCurrentUserRetriever())
 		if err != nil {
 			log.Fatal(err.Error())
 		}

--- a/router/changeLanguageHandler.go
+++ b/router/changeLanguageHandler.go
@@ -15,7 +15,7 @@ type LanguagesJSONResponse struct {
 }
 
 func SeeLanguagesHandler(w http.ResponseWriter, r *http.Request) {
-	_, Tlang := languages.GetTfuncAndLanguageFromRequest(r, "en-us")
+	_, Tlang := languages.GetTfuncAndLanguageFromRequest(r)
 	availableLanguages := languages.GetAvailableLanguages()
 
 	format := r.URL.Query().Get("format")
@@ -28,7 +28,7 @@ func SeeLanguagesHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		clv := ChangeLanguageVariables{NewSearchForm(), Navigation{}, Tlang.Tag, availableLanguages, GetUser(r), r.URL, mux.CurrentRoute(r)}
-		languages.SetTranslationFromRequest(changeLanguageTemplate, r, "en-us")
+		languages.SetTranslationFromRequest(changeLanguageTemplate, r)
 		err := changeLanguageTemplate.ExecuteTemplate(w, "index.html", clv)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/router/faqHandler.go
+++ b/router/faqHandler.go
@@ -8,7 +8,7 @@ import (
 )
 
 func FaqHandler(w http.ResponseWriter, r *http.Request) {
-	languages.SetTranslationFromRequest(faqTemplate, r, "en-us")
+	languages.SetTranslationFromRequest(faqTemplate, r)
 	err := faqTemplate.ExecuteTemplate(w, "index.html", FaqTemplateVariables{Navigation{}, NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/router/homeHandler.go
+++ b/router/homeHandler.go
@@ -56,7 +56,7 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 
 	navigationTorrents := Navigation{nbTorrents, maxPerPage, pagenum, "search_page"}
 
-	languages.SetTranslationFromRequest(homeTemplate, r, "en-us")
+	languages.SetTranslationFromRequest(homeTemplate, r)
 	htv := HomeTemplateVariables{b, NewSearchForm(), navigationTorrents, GetUser(r), r.URL, mux.CurrentRoute(r)}
 
 	err = homeTemplate.ExecuteTemplate(w, "index.html", htv)

--- a/router/modpanel.go
+++ b/router/modpanel.go
@@ -106,7 +106,6 @@ func NewPanelSearchForm() SearchForm {
 	return form
 }
 
-
 func IndexModPanel(w http.ResponseWriter, r *http.Request) {
 	currentUser := GetUser(r)
 	if userPermission.HasAdmin(currentUser) {
@@ -117,7 +116,7 @@ func IndexModPanel(w http.ResponseWriter, r *http.Request) {
 		comments, _ := commentService.GetAllComments(offset, 0, "", "")
 		torrentReports, _, _ := reportService.GetAllTorrentReports(offset, 0)
 
-		languages.SetTranslationFromRequest(panelIndex, r, "en-us")
+		languages.SetTranslationFromRequest(panelIndex, r)
 		htv := PanelIndexVbs{torrents, model.TorrentReportsToJSON(torrentReports), users, comments, NewPanelSearchForm(), currentUser, r.URL}
 		err := panelIndex.ExecuteTemplate(w, "admin_index.html", htv)
 		log.CheckError(err)
@@ -150,7 +149,7 @@ func TorrentsListPanel(w http.ResponseWriter, r *http.Request) {
 			ShowItemsPerPage: true,
 		}
 
-		languages.SetTranslationFromRequest(panelTorrentList, r, "en-us")
+		languages.SetTranslationFromRequest(panelTorrentList, r)
 		htv := PanelTorrentListVbs{torrents, searchForm, Navigation{int(searchParam.Max), offset, pagenum, "mod_tlist_page"}, currentUser, r.URL}
 		err = panelTorrentList.ExecuteTemplate(w, "admin_index.html", htv)
 		log.CheckError(err)
@@ -180,7 +179,7 @@ func TorrentReportListPanel(w http.ResponseWriter, r *http.Request) {
 		torrentReports, nbReports, _ := reportService.GetAllTorrentReports(offset, (pagenum-1)*offset)
 
 		reportJSON := model.TorrentReportsToJSON(torrentReports)
-		languages.SetTranslationFromRequest(panelTorrentReportList, r, "en-us")
+		languages.SetTranslationFromRequest(panelTorrentReportList, r)
 		htv := PanelTorrentReportListVbs{reportJSON, NewSearchForm(), Navigation{nbReports, offset, pagenum, "mod_trlist_page"}, currentUser, r.URL}
 		err = panelTorrentReportList.ExecuteTemplate(w, "admin_index.html", htv)
 		log.CheckError(err)
@@ -207,7 +206,7 @@ func UsersListPanel(w http.ResponseWriter, r *http.Request) {
 		offset := 100
 
 		users, nbUsers := userService.RetrieveUsersForAdmin(offset, (pagenum-1)*offset)
-		languages.SetTranslationFromRequest(panelUserList, r, "en-us")
+		languages.SetTranslationFromRequest(panelUserList, r)
 		htv := PanelUserListVbs{users, NewSearchForm(), Navigation{nbUsers, offset, pagenum, "mod_ulist_page"}, currentUser, r.URL}
 		err = panelUserList.ExecuteTemplate(w, "admin_index.html", htv)
 		log.CheckError(err)
@@ -241,7 +240,7 @@ func CommentsListPanel(w http.ResponseWriter, r *http.Request) {
 		}
 
 		comments, nbComments := commentService.GetAllComments(offset, (pagenum-1)*offset, conditions, values...)
-		languages.SetTranslationFromRequest(panelCommentList, r, "en-us")
+		languages.SetTranslationFromRequest(panelCommentList, r)
 		htv := PanelCommentListVbs{comments, NewSearchForm(), Navigation{nbComments, offset, pagenum, "mod_clist_page"}, currentUser, r.URL}
 		err = panelCommentList.ExecuteTemplate(w, "admin_index.html", htv)
 		log.CheckError(err)
@@ -256,7 +255,7 @@ func TorrentEditModPanel(w http.ResponseWriter, r *http.Request) {
 	if userPermission.HasAdmin(currentUser) {
 		id := r.URL.Query().Get("id")
 		torrent, _ := torrentService.GetTorrentById(id)
-		languages.SetTranslationFromRequest(panelTorrentEd, r, "en-us")
+		languages.SetTranslationFromRequest(panelTorrentEd, r)
 
 		torrentJson := torrent.ToJSON()
 		uploadForm := NewUploadForm()
@@ -302,7 +301,7 @@ func TorrentPostEditModPanel(w http.ResponseWriter, r *http.Request) {
 			infos["infos"] = append(infos["infos"], "Torrent details updated.")
 		}
 	}
-	languages.SetTranslationFromRequest(panelTorrentEd, r, "en-us")
+	languages.SetTranslationFromRequest(panelTorrentEd, r)
 	htv := PanelTorrentEdVbs{uploadForm, NewPanelSearchForm(), currentUser, err, infos, r.URL}
 	err_ := panelTorrentEd.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err_)
@@ -364,7 +363,7 @@ func TorrentReassignModPanel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "admins only", http.StatusForbidden)
 		return
 	}
-	languages.SetTranslationFromRequest(panelTorrentReassign, r, "en-us")
+	languages.SetTranslationFromRequest(panelTorrentReassign, r)
 
 	htv := PanelTorrentReassignVbs{ReassignForm{}, NewPanelSearchForm(), currentUser, form.NewErrors(), form.NewInfos(), r.URL}
 	err := panelTorrentReassign.ExecuteTemplate(w, "admin_index.html", htv)

--- a/router/notFoundHandler.go
+++ b/router/notFoundHandler.go
@@ -10,7 +10,7 @@ import (
 func NotFoundHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 
-	languages.SetTranslationFromRequest(notFoundTemplate, r, "en-us")
+	languages.SetTranslationFromRequest(notFoundTemplate, r)
 	err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{Navigation{}, NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/router/searchHandler.go
+++ b/router/searchHandler.go
@@ -44,7 +44,7 @@ func SearchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	htv := HomeTemplateVariables{b, searchForm, navigationTorrents, GetUser(r), r.URL, mux.CurrentRoute(r)}
 
-	languages.SetTranslationFromRequest(searchTemplate, r, "en-us")
+	languages.SetTranslationFromRequest(searchTemplate, r)
 	err = searchTemplate.ExecuteTemplate(w, "index.html", htv)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/router/templateFunctions.go
+++ b/router/templateFunctions.go
@@ -1,13 +1,15 @@
 package router
 
 import (
-	"github.com/ewhal/nyaa/service/user/permission"
-	"github.com/nicksnyder/go-i18n/i18n"
 	"html/template"
 	"log"
 	"math"
 	"net/url"
 	"strconv"
+
+	"github.com/ewhal/nyaa/service/user/permission"
+	"github.com/ewhal/nyaa/util/languages"
+	"github.com/nicksnyder/go-i18n/i18n"
 )
 
 var FuncMap = template.FuncMap{
@@ -92,6 +94,7 @@ var FuncMap = template.FuncMap{
 	},
 	"T":  i18n.IdentityTfunc,
 	"Ts": i18n.IdentityTfunc,
+	"getDefaultLanguage": languages.GetDefaultLanguage,
 	"getAvatar": func(hash string, size int) string {
 		return "https://www.gravatar.com/avatar/" + hash + "?s=" + strconv.Itoa(size)
 	},

--- a/router/uploadHandler.go
+++ b/router/uploadHandler.go
@@ -80,7 +80,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 
 		htv := UploadTemplateVariables{uploadForm, NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
-		languages.SetTranslationFromRequest(uploadTemplate, r, "en-us")
+		languages.SetTranslationFromRequest(uploadTemplate, r)
 		err := uploadTemplate.ExecuteTemplate(w, "index.html", htv)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/router/userHandler.go
+++ b/router/userHandler.go
@@ -22,7 +22,7 @@ func UserRegisterFormHandler(w http.ResponseWriter, r *http.Request) {
 		b := form.RegistrationForm{}
 		modelHelper.BindValueForm(&b, r)
 		b.CaptchaID = captcha.GetID()
-		languages.SetTranslationFromRequest(viewRegisterTemplate, r, "en-us")
+		languages.SetTranslationFromRequest(viewRegisterTemplate, r)
 		htv := UserRegisterTemplateVariables{b, form.NewErrors(), NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
 		err := viewRegisterTemplate.ExecuteTemplate(w, "index.html", htv)
 		if err != nil {
@@ -38,7 +38,7 @@ func UserLoginFormHandler(w http.ResponseWriter, r *http.Request) {
 	b := form.LoginForm{}
 	modelHelper.BindValueForm(&b, r)
 
-	languages.SetTranslationFromRequest(viewLoginTemplate, r, "en-us")
+	languages.SetTranslationFromRequest(viewLoginTemplate, r)
 	htv := UserLoginFormVariables{b, form.NewErrors(), NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
 
 	err := viewLoginTemplate.ExecuteTemplate(w, "index.html", htv)
@@ -65,14 +65,14 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 			if errUser != nil {
 				err["errors"] = append(err["errors"], errUser.Error())
 			}
-			languages.SetTranslationFromRequest(viewUserDeleteTemplate, r, "en-us")
+			languages.SetTranslationFromRequest(viewUserDeleteTemplate, r)
 			htv := UserVerifyTemplateVariables{err, NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
 			errorTmpl := viewUserDeleteTemplate.ExecuteTemplate(w, "index.html", htv)
 			if errorTmpl != nil {
 				http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
 			}
 		} else {
-			T := languages.SetTranslationFromRequest(viewProfileTemplate, r, "en-us")
+			T := languages.SetTranslationFromRequest(viewProfileTemplate, r)
 			if follow != nil {
 				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(T("user_followed_msg"), userProfile.Username))
 			}
@@ -87,7 +87,7 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		languages.SetTranslationFromRequest(notFoundTemplate, r, "en-us")
+		languages.SetTranslationFromRequest(notFoundTemplate, r)
 		err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{Navigation{}, NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -105,7 +105,7 @@ func UserDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		if userPermission.CurrentOrAdmin(currentUser, userProfile.ID) {
 			b := form.UserForm{}
 			modelHelper.BindValueForm(&b, r)
-			languages.SetTranslationFromRequest(viewProfileEditTemplate, r, "en-us")
+			languages.SetTranslationFromRequest(viewProfileEditTemplate, r)
 			availableLanguages := languages.GetAvailableLanguages()
 			htv := UserProfileEditVariables{&userProfile, b, form.NewErrors(), form.NewInfos(), availableLanguages, NewSearchForm(), Navigation{}, currentUser, r.URL, mux.CurrentRoute(r)}
 			err := viewProfileEditTemplate.ExecuteTemplate(w, "index.html", htv)
@@ -114,12 +114,12 @@ func UserDetailsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		languages.SetTranslationFromRequest(notFoundTemplate, r, "en-us")
+		languages.SetTranslationFromRequest(notFoundTemplate, r)
 		err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{Navigation{}, NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
- }
+	}
 }
 
 // Getting View User Profile Update
@@ -133,7 +133,7 @@ func UserProfileFormHandler(w http.ResponseWriter, r *http.Request) {
 			b := form.UserForm{}
 			err := form.NewErrors()
 			infos := form.NewInfos()
-			T := languages.SetTranslationFromRequest(viewProfileEditTemplate, r, "en-us")
+			T := languages.SetTranslationFromRequest(viewProfileEditTemplate, r)
 			if len(r.PostFormValue("email")) > 0 {
 				_, err = form.EmailValidation(r.PostFormValue("email"), err)
 			}
@@ -173,14 +173,14 @@ func UserProfileFormHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
 			}
 		} else {
-			languages.SetTranslationFromRequest(notFoundTemplate, r, "en-us")
+			languages.SetTranslationFromRequest(notFoundTemplate, r)
 			err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{Navigation{}, NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		}
 	} else {
-		languages.SetTranslationFromRequest(notFoundTemplate, r, "en-us")
+		languages.SetTranslationFromRequest(notFoundTemplate, r)
 		err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{Navigation{}, NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -209,7 +209,7 @@ func UserRegisterPostHandler(w http.ResponseWriter, r *http.Request) {
 					err["errors"] = append(err["errors"], errorUser.Error())
 				}
 				if len(err) == 0 {
-					languages.SetTranslationFromRequest(viewRegisterSuccessTemplate, r, "en-us")
+					languages.SetTranslationFromRequest(viewRegisterSuccessTemplate, r)
 					u := model.User{
 						Email: r.PostFormValue("email"), // indicate whether user had email set
 					}
@@ -224,7 +224,7 @@ func UserRegisterPostHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(err) > 0 {
 		b.CaptchaID = captcha.GetID()
-		languages.SetTranslationFromRequest(viewRegisterTemplate, r, "en-us")
+		languages.SetTranslationFromRequest(viewRegisterTemplate, r)
 		htv := UserRegisterTemplateVariables{b, err, NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
 		errorTmpl := viewRegisterTemplate.ExecuteTemplate(w, "index.html", htv)
 		if errorTmpl != nil {
@@ -241,7 +241,7 @@ func UserVerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 	if errEmail != nil {
 		err["errors"] = append(err["errors"], errEmail.Error())
 	}
-	languages.SetTranslationFromRequest(viewVerifySuccessTemplate, r, "en-us")
+	languages.SetTranslationFromRequest(viewVerifySuccessTemplate, r)
 	htv := UserVerifyTemplateVariables{err, NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
 	errorTmpl := viewVerifySuccessTemplate.ExecuteTemplate(w, "index.html", htv)
 	if errorTmpl != nil {
@@ -259,7 +259,7 @@ func UserLoginPostHandler(w http.ResponseWriter, r *http.Request) {
 		_, errorUser := userService.CreateUserAuthentication(w, r)
 		if errorUser != nil {
 			err["errors"] = append(err["errors"], errorUser.Error())
-			languages.SetTranslationFromRequest(viewLoginTemplate, r, "en-us")
+			languages.SetTranslationFromRequest(viewLoginTemplate, r)
 			htv := UserLoginFormVariables{b, err, NewSearchForm(), Navigation{}, GetUser(r), r.URL, mux.CurrentRoute(r)}
 			errorTmpl := viewLoginTemplate.ExecuteTemplate(w, "index.html", htv)
 			if errorTmpl != nil {

--- a/router/viewTorrentHandler.go
+++ b/router/viewTorrentHandler.go
@@ -34,7 +34,7 @@ func ViewHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	htv := ViewTemplateVariables{b, captchaID, NewSearchForm(), Navigation{}, user, r.URL, mux.CurrentRoute(r)}
 
-	languages.SetTranslationFromRequest(viewTemplate, r, "en-us")
+	languages.SetTranslationFromRequest(viewTemplate, r)
 	err = viewTemplate.ExecuteTemplate(w, "index.html", htv)
 	if err != nil {
 		log.Errorf("ViewHandler(): %s", err)

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -17,6 +17,17 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+func NewCurrentUserRetriever() *CurrentUserRetriever {
+	return &CurrentUserRetriever{}
+}
+
+type CurrentUserRetriever struct{}
+
+func (*CurrentUserRetriever) RetrieveCurrentUser(r *http.Request) (model.User, error) {
+	user, _, err := RetrieveCurrentUser(r)
+	return user, err
+}
+
 // SuggestUsername suggest user's name if user's name already occupied.
 func SuggestUsername(username string) string {
 	var count int
@@ -104,7 +115,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) (int, error) {
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-	if (registrationForm.Email != "") {
+	if registrationForm.Email != "" {
 		SendVerificationToUser(user, registrationForm.Email)
 	}
 	status, err = RegisterHandler(w, r)
@@ -185,7 +196,7 @@ func UpdateUser(w http.ResponseWriter, form *formStruct.UserForm, currentUser *m
 		form.Status = user.Status
 		form.Username = user.Username
 	}
-	if (form.Email != user.Email) {
+	if form.Email != user.Email {
 		// send verification to new email and keep old
 		SendVerificationToUser(user, form.Email)
 		form.Email = user.Email
@@ -202,7 +213,7 @@ func DeleteUser(w http.ResponseWriter, currentUser *model.User, id string) (int,
 	if db.ORM.First(&user, id).RecordNotFound() {
 		return http.StatusNotFound, errors.New("user not found")
 	}
-	if (user.ID == 0) {
+	if user.ID == 0 {
 		return http.StatusInternalServerError, errors.New("You can't delete that!")
 	}
 	if db.ORM.Delete(&user).Error != nil {

--- a/service/user/verification.go
+++ b/service/user/verification.go
@@ -11,16 +11,16 @@ import (
 	"github.com/ewhal/nyaa/db"
 	"github.com/ewhal/nyaa/model"
 	"github.com/ewhal/nyaa/util/email"
+	"github.com/ewhal/nyaa/util/languages"
 	"github.com/ewhal/nyaa/util/timeHelper"
 	"github.com/gorilla/securecookie"
-	"github.com/nicksnyder/go-i18n/i18n"
 )
 
 var verificationHandler = securecookie.New(config.EmailTokenHashKey, nil)
 
 // SendEmailVerfication sends an email verification token via email.
-func SendEmailVerification(to string, token string, locale string) error {
-	T, err := i18n.Tfunc(locale)
+func SendEmailVerification(to string, token string) error {
+	T, err := languages.GetDefaultTfunc()
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func SendVerificationToUser(user model.User, newEmail string) (int, error) {
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-	err = SendEmailVerification(newEmail, encoded, "en-us")
+	err = SendEmailVerification(newEmail, encoded)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/templates/_profile_edit.html
+++ b/templates/_profile_edit.html
@@ -29,7 +29,7 @@
                 <select id="language" name="language" class="form-control">
 					{{ $userLanguage := .Language }}
 					{{ range $tag, $translatedName := $.Languages }}
-	                	<option value="{{ $tag }}" {{ if or (eq $userLanguage $tag) (and (eq $userLanguage "") (eq $tag "en-us")) }}selected{{end}}>{{ $translatedName }} {{if eq $tag "en-us"}}({{ T "default" }}){{end}}</option>
+						<option value="{{ $tag }}" {{ if or (eq $userLanguage $tag) (and (eq $userLanguage "") (eq $tag getDefaultLanguage)) }}selected{{end}}>{{ $translatedName }} {{if eq $tag getDefaultLanguage}}({{ T "default" }}){{end}}</option>
 					{{ end }}
                 </select>
               </div>

--- a/util/languages/translation_test.go
+++ b/util/languages/translation_test.go
@@ -10,8 +10,9 @@ import (
 func TestInitI18n(t *testing.T) {
 	conf := config.DefaultI18nConfig
 	conf.TranslationsDirectory = path.Join("..", "..", conf.TranslationsDirectory)
+	var retriever UserRetriever = nil // not required during initialization
 
-	err := InitI18n(conf)
+	err := InitI18n(conf, retriever)
 	if err != nil {
 		t.Errorf("failed to initialize language translations: %v", err)
 	}


### PR DESCRIPTION
This consolidates the places where a default language has to be set.

- Removed import of the 'userService' package into the 'languages' util
  package
  This was required to prevent a cyclic import between the two packages.
- Added a 'UserRetriever' interface to read the language setting of users
  inside the 'languages' package