### PR TITLE
Store torrent FileList info as bencoded data.

### DIFF
--- a/model/file.go
+++ b/model/file.go
@@ -1,14 +1,34 @@
 package model
 
+import (
+	"github.com/zeebo/bencode"
+)
+
 type File struct {
-	ID        uint   `gorm:"column:file_id;primary_key"`
-	TorrentID uint   `gorm:"column:torrent_id;unique_index:idx_tid_path"`
-	Path      string `gorm:"column:path;unique_index:idx_tid_path"`
-	Filesize  int64  `gorm:"column:filesize"`
+	ID           uint   `gorm:"column:file_id;primary_key"`
+	TorrentID    uint   `gorm:"column:torrent_id;unique_index:idx_tid_path"`
+	// this path is bencode'd, call Path() to obtain
+	BencodedPath string `gorm:"column:path;unique_index:idx_tid_path"`
+	Filesize     int64  `gorm:"column:filesize"`
 }
 
 // Returns the total size of memory allocated for this struct
 func (f File) Size() int {
-	return (2 + len(f.Path) + 2) * 8;
+	return (2 + len(f.BencodedPath) + 1) * 8;
+}
+
+func (f *File) Path() (out []string) {
+	bencode.DecodeString(f.BencodedPath, &out)
+	return
+}
+
+func (f *File) SetPath(path []string) error {
+	encoded, err := bencode.EncodeString(path)
+	if err != nil {
+		return err
+	}
+
+	f.BencodedPath = encoded
+	return nil
 }
 

--- a/model/torrent.go
+++ b/model/torrent.go
@@ -6,6 +6,7 @@ import (
 
 	"fmt"
 	"html/template"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -131,7 +132,10 @@ func (t *Torrent) ToJSON() TorrentJSON {
 	}
 	fileListJSON := make([]FileJSON, 0, len(t.FileList))
 	for _, f := range t.FileList {
-		fileListJSON = append(fileListJSON, FileJSON{Path: f.Path, Filesize: util.FormatFilesize2(f.Filesize)})
+		fileListJSON = append(fileListJSON, FileJSON{
+			Path: filepath.Join(f.Path()...),
+			Filesize: util.FormatFilesize2(f.Filesize),
+		})
 	}
 	uploader := ""
 	if t.Uploader != nil {

--- a/router/upload.go
+++ b/router/upload.go
@@ -27,7 +27,7 @@ import (
 // Use this, because we seem to avoid using models, and we would need
 // the torrent ID to create the File in the DB
 type UploadedFile struct {
-	Path     string
+	Path     []string
 	Filesize int64
 }
 
@@ -161,10 +161,10 @@ func (f *UploadForm) ExtractInfo(r *http.Request) error {
 		
 		// extract filelist
 		fileInfos := torrent.Info.GetFiles()
-		for _, info := range fileInfos {
+		for _, fileInfo := range fileInfos {
 			f.FileList = append(f.FileList, UploadedFile{
-				Path: info.Path.FilePath(),
-				Filesize: int64(info.Length),
+				Path: fileInfo.Path,
+				Filesize: int64(fileInfo.Length),
 			})
 		}
 	} else {

--- a/router/uploadHandler.go
+++ b/router/uploadHandler.go
@@ -64,10 +64,12 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 			// add filelist to files db, if we have one
 			if len(uploadForm.FileList) > 0 {
 				for _, uploadedFile := range uploadForm.FileList {
-					file := model.File{
-						TorrentID: torrent.ID,
-						Path: uploadedFile.Path,
-						Filesize: uploadedFile.Filesize}
+					file := model.File{TorrentID: torrent.ID, Filesize: uploadedFile.Filesize}
+					err := file.SetPath(uploadedFile.Path)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
 					db.ORM.Create(&file)
 				}
 			}


### PR DESCRIPTION
Probably will be needed for #516 treeview.

A torrent metadata stores individual filepaths as a bencoded array, consisting of a directory structure - so, `dir1/dir2/file3.txt` is stored as `["dir1", "dir2", "file3.txt"]`. We stored the path in the database by joining the array with forward-slashes.

However, it's possible that a torrent has a path with forward-slashes on it: `["foo/bar", "file.txt"]`, where "foo/bar" is a single directory. [Although invalid by some clients](http://blog.libtorrent.org/2014/12/filenames/) due to filesystem rules, we should store it accordingly.