### PR TITLE
Added torrent rss fields

### DIFF
--- a/feeds/.travis.yml
+++ b/feeds/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+sudo: false
+go:
+  - 1.3
+  - 1.4
+  - 1.5
+  - tip
+install:
+  - go get golang.org/x/tools/cmd/vet
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/feeds/LICENSE
+++ b/feeds/LICENSE
@@ -1,0 +1,22 @@
+Original Work Copyright (c) 2013 The Gorilla Feeds Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -1,0 +1,140 @@
+## gorilla/feeds
+[![GoDoc](https://godoc.org/github.com/gorilla/feeds?status.svg)](https://godoc.org/github.com/gorilla/feeds) [![Build Status](https://travis-ci.org/gorilla/feeds.png?branch=master)](https://travis-ci.org/gorilla/feeds)
+
+feeds is a web feed generator library for generating RSS and Atom feeds from Go
+applications.
+
+### Goals
+
+ * Provide a simple interface to create both Atom & RSS 2.0 feeds
+ * Full support for Atom and RSS2.0 spec elements
+ * Ability to modify particulars for each spec
+
+### Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+    "github.com/gorilla/feeds"
+)
+
+func main() {
+    now := time.Now()
+    feed := &feeds.Feed{
+        Title:       "jmoiron.net blog",
+        Link:        &feeds.Link{Href: "http://jmoiron.net/blog"},
+        Description: "discussion about tech, footie, photos",
+        Author:      &feeds.Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
+        Created:     now,
+    }
+
+    feed.Items = []*feeds.Item{
+        &feeds.Item{
+            Title:       "Limiting Concurrency in Go",
+            Link:        &feeds.Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
+            Description: "A discussion on controlled parallelism in golang",
+            Author:      &feeds.Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
+            Created:     now,
+        },
+        &feeds.Item{
+            Title:       "Logic-less Template Redux",
+            Link:        &feeds.Link{Href: "http://jmoiron.net/blog/logicless-template-redux/"},
+            Description: "More thoughts on logicless templates",
+            Created:     now,
+        },
+        &feeds.Item{
+            Title:       "Idiomatic Code Reuse in Go",
+            Link:        &feeds.Link{Href: "http://jmoiron.net/blog/idiomatic-code-reuse-in-go/"},
+            Description: "How to use interfaces <em>effectively</em>",
+            Created:     now,
+        },
+    }
+
+    atom, err := feed.ToAtom()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    rss, err := feed.ToRss()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(atom, "\n", rss)
+}
+```
+
+Outputs:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>jmoiron.net blog</title>
+  <link href="http://jmoiron.net/blog"></link>
+  <id>http://jmoiron.net/blog</id>
+  <updated>2013-01-16T03:26:01-05:00</updated>
+  <summary>discussion about tech, footie, photos</summary>
+  <entry>
+    <title>Limiting Concurrency in Go</title>
+    <link href="http://jmoiron.net/blog/limiting-concurrency-in-go/"></link>
+    <updated>2013-01-16T03:26:01-05:00</updated>
+    <id>tag:jmoiron.net,2013-01-16:/blog/limiting-concurrency-in-go/</id>
+    <summary type="html">A discussion on controlled parallelism in golang</summary>
+    <author>
+      <name>Jason Moiron</name>
+      <email>jmoiron@jmoiron.net</email>
+    </author>
+  </entry>
+  <entry>
+    <title>Logic-less Template Redux</title>
+    <link href="http://jmoiron.net/blog/logicless-template-redux/"></link>
+    <updated>2013-01-16T03:26:01-05:00</updated>
+    <id>tag:jmoiron.net,2013-01-16:/blog/logicless-template-redux/</id>
+    <summary type="html">More thoughts on logicless templates</summary>
+    <author></author>
+  </entry>
+  <entry>
+    <title>Idiomatic Code Reuse in Go</title>
+    <link href="http://jmoiron.net/blog/idiomatic-code-reuse-in-go/"></link>
+    <updated>2013-01-16T03:26:01-05:00</updated>
+    <id>tag:jmoiron.net,2013-01-16:/blog/idiomatic-code-reuse-in-go/</id>
+    <summary type="html">How to use interfaces &lt;em&gt;effectively&lt;/em&gt;</summary>
+    <author></author>
+  </entry>
+</feed>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>jmoiron.net blog</title>
+    <link>http://jmoiron.net/blog</link>
+    <description>discussion about tech, footie, photos</description>
+    <managingEditor>jmoiron@jmoiron.net (Jason Moiron)</managingEditor>
+    <pubDate>2013-01-16T03:22:24-05:00</pubDate>
+    <item>
+      <title>Limiting Concurrency in Go</title>
+      <link>http://jmoiron.net/blog/limiting-concurrency-in-go/</link>
+      <description>A discussion on controlled parallelism in golang</description>
+      <pubDate>2013-01-16T03:22:24-05:00</pubDate>
+    </item>
+    <item>
+      <title>Logic-less Template Redux</title>
+      <link>http://jmoiron.net/blog/logicless-template-redux/</link>
+      <description>More thoughts on logicless templates</description>
+      <pubDate>2013-01-16T03:22:24-05:00</pubDate>
+    </item>
+    <item>
+      <title>Idiomatic Code Reuse in Go</title>
+      <link>http://jmoiron.net/blog/idiomatic-code-reuse-in-go/</link>
+      <description>How to use interfaces &lt;em&gt;effectively&lt;/em&gt;</description>
+      <pubDate>2013-01-16T03:22:24-05:00</pubDate>
+    </item>
+  </channel>
+</rss>
+
+```
+

--- a/feeds/atom.go
+++ b/feeds/atom.go
@@ -1,0 +1,163 @@
+package feeds
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// Generates Atom feed as XML
+
+const ns = "http://www.w3.org/2005/Atom"
+
+type AtomPerson struct {
+	Name  string `xml:"name,omitempty"`
+	Uri   string `xml:"uri,omitempty"`
+	Email string `xml:"email,omitempty"`
+}
+
+type AtomSummary struct {
+	XMLName xml.Name `xml:"summary"`
+	Content string   `xml:",chardata"`
+	Type    string   `xml:"type,attr"`
+}
+
+type AtomContent struct {
+	XMLName xml.Name `xml:"content"`
+	Content string   `xml:",chardata"`
+	Type    string   `xml:"type,attr"`
+}
+
+type AtomAuthor struct {
+	XMLName xml.Name `xml:"author"`
+	AtomPerson
+}
+
+type AtomContributor struct {
+	XMLName xml.Name `xml:"contributor"`
+	AtomPerson
+}
+
+type AtomEntry struct {
+	XMLName     xml.Name `xml:"entry"`
+	Xmlns       string   `xml:"xmlns,attr,omitempty"`
+	Title       string   `xml:"title"`   // required
+	Updated     string   `xml:"updated"` // required
+	Id          string   `xml:"id"`      // required
+	Category    string   `xml:"category,omitempty"`
+	Content     *AtomContent
+	Rights      string `xml:"rights,omitempty"`
+	Source      string `xml:"source,omitempty"`
+	Published   string `xml:"published,omitempty"`
+	Contributor *AtomContributor
+	Link        *AtomLink    // required if no child 'content' elements
+	Summary     *AtomSummary // required if content has src or content is base64
+	Author      *AtomAuthor  // required if feed lacks an author
+}
+
+type AtomLink struct {
+	//Atom 1.0 <link rel="enclosure" type="audio/mpeg" title="MP3" href="http://www.example.org/myaudiofile.mp3" length="1234" />
+	XMLName xml.Name `xml:"link"`
+	Href    string   `xml:"href,attr"`
+	Rel     string   `xml:"rel,attr,omitempty"`
+	Type    string   `xml:"type,attr,omitempty"`
+	Length  string   `xml:"length,attr,omitempty"`
+}
+
+type AtomFeed struct {
+	XMLName     xml.Name `xml:"feed"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Title       string   `xml:"title"`   // required
+	Id          string   `xml:"id"`      // required
+	Updated     string   `xml:"updated"` // required
+	Category    string   `xml:"category,omitempty"`
+	Icon        string   `xml:"icon,omitempty"`
+	Logo        string   `xml:"logo,omitempty"`
+	Rights      string   `xml:"rights,omitempty"` // copyright used
+	Subtitle    string   `xml:"subtitle,omitempty"`
+	Link        *AtomLink
+	Author      *AtomAuthor `xml:"author,omitempty"`
+	Contributor *AtomContributor
+	Entries     []*AtomEntry
+}
+
+type Atom struct {
+	*Feed
+}
+
+func newAtomEntry(i *Item) *AtomEntry {
+	id := i.Id
+	// assume the description is html
+	c := &AtomContent{Content: i.Description, Type: "html"}
+
+	if len(id) == 0 {
+		// if there's no id set, try to create one, either from data or just a uuid
+		if len(i.Link.Href) > 0 && (!i.Created.IsZero() || !i.Updated.IsZero()) {
+			dateStr := anyTimeFormat("2006-01-02", i.Updated, i.Created)
+			host, path := i.Link.Href, "/invalid.html"
+			if url, err := url.Parse(i.Link.Href); err == nil {
+				host, path = url.Host, url.Path
+			}
+			id = fmt.Sprintf("tag:%s,%s:%s", host, dateStr, path)
+		} else {
+			id = "urn:uuid:" + NewUUID().String()
+		}
+	}
+	var name, email string
+	if i.Author != nil {
+		name, email = i.Author.Name, i.Author.Email
+	}
+
+	x := &AtomEntry{
+		Title:   i.Title,
+		Link:    &AtomLink{Href: i.Link.Href, Rel: i.Link.Rel, Type: i.Link.Type},
+		Content: c,
+		Id:      id,
+		Updated: anyTimeFormat(time.RFC3339, i.Updated, i.Created),
+	}
+
+	intLength, err := strconv.ParseInt(i.Link.Length, 10, 64)
+
+	if err == nil && (intLength > 0 || i.Link.Type != "") {
+		i.Link.Rel = "enclosure"
+		x.Link = &AtomLink{Href: i.Link.Href, Rel: i.Link.Rel, Type: i.Link.Type, Length: i.Link.Length}
+	}
+
+	if len(name) > 0 || len(email) > 0 {
+		x.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: name, Email: email}}
+	}
+	return x
+}
+
+// create a new AtomFeed with a generic Feed struct's data
+func (a *Atom) AtomFeed() *AtomFeed {
+	updated := anyTimeFormat(time.RFC3339, a.Updated, a.Created)
+	feed := &AtomFeed{
+		Xmlns:    ns,
+		Title:    a.Title,
+		Link:     &AtomLink{Href: a.Link.Href, Rel: a.Link.Rel},
+		Subtitle: a.Description,
+		Id:       a.Link.Href,
+		Updated:  updated,
+		Rights:   a.Copyright,
+	}
+	if a.Author != nil {
+		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: a.Author.Name, Email: a.Author.Email}}
+	}
+	for _, e := range a.Items {
+		feed.Entries = append(feed.Entries, newAtomEntry(e))
+	}
+	return feed
+}
+
+// return an XML-Ready object for an Atom object
+func (a *Atom) FeedXml() interface{} {
+	return a.AtomFeed()
+}
+
+// return an XML-ready object for an AtomFeed object
+func (a *AtomFeed) FeedXml() interface{} {
+	return a
+}

--- a/feeds/doc.go
+++ b/feeds/doc.go
@@ -1,0 +1,70 @@
+/*
+Syndication (feed) generator library for golang.
+
+Installing
+
+	go get github.com/gorilla/feeds
+
+Feeds provides a simple, generic Feed interface with a generic Item object as well as RSS and Atom specific RssFeed and AtomFeed objects which allow access to all of each spec's defined elements.
+
+Examples
+
+Create a Feed and some Items in that feed using the generic interfaces:
+
+	import (
+		"time"
+		. "github.com/gorilla/feeds
+	)
+
+	now = time.Now()
+
+	feed := &Feed{
+		Title:       "jmoiron.net blog",
+		Link:        &Link{Href: "http://jmoiron.net/blog"},
+		Description: "discussion about tech, footie, photos",
+		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
+		Created:     now,
+		Copyright:   "This work is copyright © Benjamin Button",
+	}
+
+	feed.Items = []*Item{
+		&Item{
+			Title:       "Limiting Concurrency in Go",
+			Link:        &Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
+			Description: "A discussion on controlled parallelism in golang",
+			Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
+			Created:     now,
+		},
+		&Item{
+			Title:       "Logic-less Template Redux",
+			Link:        &Link{Href: "http://jmoiron.net/blog/logicless-template-redux/"},
+			Description: "More thoughts on logicless templates",
+			Created:     now,
+		},
+		&Item{
+			Title:       "Idiomatic Code Reuse in Go",
+			Link:        &Link{Href: "http://jmoiron.net/blog/idiomatic-code-reuse-in-go/"},
+			Description: "How to use interfaces <em>effectively</em>",
+			Created:     now,
+		},
+	}
+
+From here, you can output Atom or RSS versions of this feed easily
+
+	atom, err := feed.ToAtom()
+	rss, err := feed.ToRss()
+
+You can also get access to the underlying objects that feeds uses to export its XML
+
+	atomFeed := &Atom{feed}.AtomFeed()
+	rssFeed := &Rss{feed}.RssFeed()
+
+From here, you can modify or add each syndication's specific fields before outputting
+
+	atomFeed.Subtitle = "plays the blues"
+	atom, err := ToXML(atomFeed)
+	rssFeed.Generator = "gorilla/feeds v1.0 (github.com/gorilla/feeds)"
+	rss, err := ToXML(rssFeed)
+
+*/
+package feeds

--- a/feeds/feed.go
+++ b/feeds/feed.go
@@ -16,9 +16,11 @@ type Author struct {
 
 // modified for Nyaa
 type Torrent struct {
-	Seeders  uint32
-	Leechers uint32
-	Hash     string
+	Seeders    uint32
+	Leechers   uint32
+	Hash       string
+	Completed  uint32
+	LastScrape time.Time
 }
 
 type Item struct {

--- a/feeds/feed.go
+++ b/feeds/feed.go
@@ -1,0 +1,115 @@
+package feeds
+
+import (
+	"encoding/xml"
+	"io"
+	"time"
+)
+
+type Link struct {
+	Href, Rel, Type, Length string
+}
+
+type Author struct {
+	Name, Email string
+}
+
+// modified for Nyaa
+type Torrent struct {
+	Seeders  uint32
+	Leechers uint32
+	Hash     string
+}
+
+type Item struct {
+	Title       string
+	Link        *Link
+	Author      *Author
+	Description string // used as description in rss, summary in atom
+	Id          string // used as guid in rss, id in atom
+	Updated     time.Time
+	Created     time.Time
+
+	Torrent *Torrent // modified for Nyaa
+}
+
+type Feed struct {
+	Title       string
+	Link        *Link
+	Description string
+	Author      *Author
+	Updated     time.Time
+	Created     time.Time
+	Id          string
+	Subtitle    string
+	Items       []*Item
+	Copyright   string
+}
+
+// add a new Item to a Feed
+func (f *Feed) Add(item *Item) {
+	f.Items = append(f.Items, item)
+}
+
+// returns the first non-zero time formatted as a string or ""
+func anyTimeFormat(format string, times ...time.Time) string {
+	for _, t := range times {
+		if !t.IsZero() {
+			return t.Format(format)
+		}
+	}
+	return ""
+}
+
+// interface used by ToXML to get a object suitable for exporting XML.
+type XmlFeed interface {
+	FeedXml() interface{}
+}
+
+// turn a feed object (either a Feed, AtomFeed, or RssFeed) into xml
+// returns an error if xml marshaling fails
+func ToXML(feed XmlFeed) (string, error) {
+	x := feed.FeedXml()
+	data, err := xml.MarshalIndent(x, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	// strip empty line from default xml header
+	s := xml.Header[:len(xml.Header)-1] + string(data)
+	return s, nil
+}
+
+// Write a feed object (either a Feed, AtomFeed, or RssFeed) as XML into
+// the writer. Returns an error if XML marshaling fails.
+func WriteXML(feed XmlFeed, w io.Writer) error {
+	x := feed.FeedXml()
+	// write default xml header, without the newline
+	if _, err := w.Write([]byte(xml.Header[:len(xml.Header)-1])); err != nil {
+		return err
+	}
+	e := xml.NewEncoder(w)
+	e.Indent("", "  ")
+	return e.Encode(x)
+}
+
+// creates an Atom representation of this feed
+func (f *Feed) ToAtom() (string, error) {
+	a := &Atom{f}
+	return ToXML(a)
+}
+
+// Writes an Atom representation of this feed to the writer.
+func (f *Feed) WriteAtom(w io.Writer) error {
+	return WriteXML(&Atom{f}, w)
+}
+
+// creates an Rss representation of this feed
+func (f *Feed) ToRss() (string, error) {
+	r := &Rss{f}
+	return ToXML(r)
+}
+
+// Writes an RSS representation of this feed to the writer.
+func (f *Feed) WriteRss(w io.Writer) error {
+	return WriteXML(&Rss{f}, w)
+}

--- a/feeds/feed_test.go
+++ b/feeds/feed_test.go
@@ -1,0 +1,183 @@
+package feeds
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom">
+  <title>jmoiron.net blog</title>
+  <id>http://jmoiron.net/blog</id>
+  <updated>2013-01-16T21:52:35-05:00</updated>
+  <rights>This work is copyright © Benjamin Button</rights>
+  <subtitle>discussion about tech, footie, photos</subtitle>
+  <link href="http://jmoiron.net/blog"></link>
+  <author>
+    <name>Jason Moiron</name>
+    <email>jmoiron@jmoiron.net</email>
+  </author>
+  <entry>
+    <title>Limiting Concurrency in Go</title>
+    <updated>2013-01-16T21:52:35-05:00</updated>
+    <id>tag:jmoiron.net,2013-01-16:/blog/limiting-concurrency-in-go/</id>
+    <content type="html">A discussion on controlled parallelism in golang</content>
+    <link href="http://jmoiron.net/blog/limiting-concurrency-in-go/"></link>
+    <author>
+      <name>Jason Moiron</name>
+      <email>jmoiron@jmoiron.net</email>
+    </author>
+  </entry>
+  <entry>
+    <title>Logic-less Template Redux</title>
+    <updated>2013-01-16T21:52:35-05:00</updated>
+    <id>tag:jmoiron.net,2013-01-16:/blog/logicless-template-redux/</id>
+    <content type="html">More thoughts on logicless templates</content>
+    <link href="http://jmoiron.net/blog/logicless-template-redux/"></link>
+  </entry>
+  <entry>
+    <title>Idiomatic Code Reuse in Go</title>
+    <updated>2013-01-16T21:52:35-05:00</updated>
+    <id>tag:jmoiron.net,2013-01-16:/blog/idiomatic-code-reuse-in-go/</id>
+    <content type="html">How to use interfaces &lt;em&gt;effectively&lt;/em&gt;</content>
+    <link href="http://jmoiron.net/blog/idiomatic-code-reuse-in-go/"></link>
+  </entry>
+  <entry>
+    <title>Never Gonna Give You Up Mp3</title>
+    <updated>2013-01-16T21:52:35-05:00</updated>
+    <id>tag:example.com,2013-01-16:/RickRoll.mp3</id>
+    <content type="html">Never gonna give you up - Never gonna let you down.</content>
+    <link href="http://example.com/RickRoll.mp3" rel="enclosure" type="audio/mpeg" length="123456"></link>
+  </entry>
+  <entry>
+    <title>String formatting in Go</title>
+    <updated>2013-01-16T21:52:35-05:00</updated>
+    <id>tag:example.com,2013-01-16:/strings</id>
+    <content type="html">How to use things like %s, %v, %d, etc.</content>
+    <link href="http://example.com/strings"></link>
+  </entry>
+</feed>`
+
+var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0">
+  <channel>
+    <title>jmoiron.net blog</title>
+    <link>http://jmoiron.net/blog</link>
+    <description>discussion about tech, footie, photos</description>
+    <copyright>This work is copyright © Benjamin Button</copyright>
+    <managingEditor>jmoiron@jmoiron.net (Jason Moiron)</managingEditor>
+    <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+    <item>
+      <title>Limiting Concurrency in Go</title>
+      <link>http://jmoiron.net/blog/limiting-concurrency-in-go/</link>
+      <description>A discussion on controlled parallelism in golang</description>
+      <author>Jason Moiron</author>
+      <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+    </item>
+    <item>
+      <title>Logic-less Template Redux</title>
+      <link>http://jmoiron.net/blog/logicless-template-redux/</link>
+      <description>More thoughts on logicless templates</description>
+      <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+    </item>
+    <item>
+      <title>Idiomatic Code Reuse in Go</title>
+      <link>http://jmoiron.net/blog/idiomatic-code-reuse-in-go/</link>
+      <description>How to use interfaces &lt;em&gt;effectively&lt;/em&gt;</description>
+      <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+    </item>
+    <item>
+      <title>Never Gonna Give You Up Mp3</title>
+      <link>http://example.com/RickRoll.mp3</link>
+      <description>Never gonna give you up - Never gonna let you down.</description>
+      <enclosure url="http://example.com/RickRoll.mp3" length="123456" type="audio/mpeg"></enclosure>
+      <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+    </item>
+    <item>
+      <title>String formatting in Go</title>
+      <link>http://example.com/strings</link>
+      <description>How to use things like %s, %v, %d, etc.</description>
+      <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+    </item>
+  </channel>
+</rss>`
+
+func TestFeed(t *testing.T) {
+	now, err := time.Parse(time.RFC3339, "2013-01-16T21:52:35-05:00")
+	if err != nil {
+		t.Error(err)
+	}
+	tz := time.FixedZone("EST", -5*60*60)
+	now = now.In(tz)
+
+	feed := &Feed{
+		Title:       "jmoiron.net blog",
+		Link:        &Link{Href: "http://jmoiron.net/blog"},
+		Description: "discussion about tech, footie, photos",
+		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
+		Created:     now,
+		Copyright:   "This work is copyright © Benjamin Button",
+	}
+
+	feed.Items = []*Item{
+		{
+			Title:       "Limiting Concurrency in Go",
+			Link:        &Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
+			Description: "A discussion on controlled parallelism in golang",
+			Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
+			Created:     now,
+		},
+		{
+			Title:       "Logic-less Template Redux",
+			Link:        &Link{Href: "http://jmoiron.net/blog/logicless-template-redux/"},
+			Description: "More thoughts on logicless templates",
+			Created:     now,
+		},
+		{
+			Title:       "Idiomatic Code Reuse in Go",
+			Link:        &Link{Href: "http://jmoiron.net/blog/idiomatic-code-reuse-in-go/"},
+			Description: "How to use interfaces <em>effectively</em>",
+			Created:     now,
+		},
+		{
+			Title:       "Never Gonna Give You Up Mp3",
+			Link:        &Link{Href: "http://example.com/RickRoll.mp3", Length: "123456", Type: "audio/mpeg"},
+			Description: "Never gonna give you up - Never gonna let you down.",
+			Created:     now,
+		},
+		{
+			Title:       "String formatting in Go",
+			Link:        &Link{Href: "http://example.com/strings"},
+			Description: "How to use things like %s, %v, %d, etc.",
+			Created:     now,
+		}}
+
+	atom, err := feed.ToAtom()
+	if err != nil {
+		t.Errorf("unexpected error encoding Atom: %v", err)
+	}
+	if atom != atomOutput {
+		t.Errorf("Atom not what was expected.  Got:\n%s\n\nExpected:\n%s\n", atom, atomOutput)
+	}
+	var buf bytes.Buffer
+	if err := feed.WriteAtom(&buf); err != nil {
+		t.Errorf("unexpected error writing Atom: %v", err)
+	}
+	if got := buf.String(); got != atomOutput {
+		t.Errorf("Atom not what was expected.  Got:\n%s\n\nExpected:\n%s\n", got, atomOutput)
+	}
+
+	rss, err := feed.ToRss()
+	if err != nil {
+		t.Errorf("unexpected error encoding RSS: %v", err)
+	}
+	if rss != rssOutput {
+		t.Errorf("Rss not what was expected.  Got:\n%s\n\nExpected:\n%s\n", rss, rssOutput)
+	}
+	buf.Reset()
+	if err := feed.WriteRss(&buf); err != nil {
+		t.Errorf("unexpected error writing RSS: %v", err)
+	}
+	if got := buf.String(); got != rssOutput {
+		t.Errorf("Rss not what was expected.  Got:\n%s\n\nExpected:\n%s\n", got, rssOutput)
+	}
+}

--- a/feeds/rss.go
+++ b/feeds/rss.go
@@ -1,0 +1,155 @@
+package feeds
+
+// rss support
+// validation done according to spec here:
+//    http://cyber.law.harvard.edu/rss/rss.html
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// private wrapper around the RssFeed which gives us the <rss>..</rss> xml
+type rssFeedXml struct {
+	XMLName      xml.Name `xml:"rss"`
+	Version      string   `xml:"version,attr"`
+	Channel      *RssFeed
+	XMLNSTorrent string `xml:"xmlns:torrent,attr"` // modified for Nyaa
+}
+
+type RssImage struct {
+	XMLName xml.Name `xml:"image"`
+	Url     string   `xml:"url"`
+	Title   string   `xml:"title"`
+	Link    string   `xml:"link"`
+	Width   int      `xml:"width,omitempty"`
+	Height  int      `xml:"height,omitempty"`
+}
+
+type RssTextInput struct {
+	XMLName     xml.Name `xml:"textInput"`
+	Title       string   `xml:"title"`
+	Description string   `xml:"description"`
+	Name        string   `xml:"name"`
+	Link        string   `xml:"link"`
+}
+
+type RssFeed struct {
+	XMLName        xml.Name `xml:"channel"`
+	Title          string   `xml:"title"`       // required
+	Link           string   `xml:"link"`        // required
+	Description    string   `xml:"description"` // required
+	Language       string   `xml:"language,omitempty"`
+	Copyright      string   `xml:"copyright,omitempty"`
+	ManagingEditor string   `xml:"managingEditor,omitempty"` // Author used
+	WebMaster      string   `xml:"webMaster,omitempty"`
+	PubDate        string   `xml:"pubDate,omitempty"`       // created or updated
+	LastBuildDate  string   `xml:"lastBuildDate,omitempty"` // updated used
+	Category       string   `xml:"category,omitempty"`
+	Generator      string   `xml:"generator,omitempty"`
+	Docs           string   `xml:"docs,omitempty"`
+	Cloud          string   `xml:"cloud,omitempty"`
+	Ttl            int      `xml:"ttl,omitempty"`
+	Rating         string   `xml:"rating,omitempty"`
+	SkipHours      string   `xml:"skipHours,omitempty"`
+	SkipDays       string   `xml:"skipDays,omitempty"`
+	Image          *RssImage
+	TextInput      *RssTextInput
+	Items          []*RssItem
+}
+
+type RssItem struct {
+	XMLName     xml.Name `xml:"item"`
+	Title       string   `xml:"title"`       // required
+	Link        string   `xml:"link"`        // required
+	Description string   `xml:"description"` // required
+	Author      string   `xml:"author,omitempty"`
+	Category    string   `xml:"category,omitempty"`
+	Comments    string   `xml:"comments,omitempty"`
+	Enclosure   *RssEnclosure
+	Guid        string `xml:"guid,omitempty"`    // Id used
+	PubDate     string `xml:"pubDate,omitempty"` // created or updated
+	Source      string `xml:"source,omitempty"`
+
+	Seeders  uint32 `xml:"torrent:seeders"`  // modified for Nyaa
+	Leechers uint32 `xml:"torrent:leechers"` // modified for Nyaa
+	Hash     string `xml:"torrent:hash"`     // modified for Nyaa
+}
+
+type RssEnclosure struct {
+	//RSS 2.0 <enclosure url="http://example.com/file.mp3" length="123456789" type="audio/mpeg" />
+	XMLName xml.Name `xml:"enclosure"`
+	Url     string   `xml:"url,attr"`
+	Length  string   `xml:"length,attr"`
+	Type    string   `xml:"type,attr"`
+}
+
+type Rss struct {
+	*Feed
+}
+
+// create a new RssItem with a generic Item struct's data
+func newRssItem(i *Item) *RssItem {
+	item := &RssItem{
+		Title:       i.Title,
+		Link:        i.Link.Href,
+		Description: i.Description,
+		Guid:        i.Id,
+		PubDate:     anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
+
+		Seeders:  i.Torrent.Seeders,  // modified for Nyaa
+		Leechers: i.Torrent.Leechers, // modified for Nyaa
+	}
+
+	intLength, err := strconv.ParseInt(i.Link.Length, 10, 64)
+
+	if err == nil && (intLength > 0 || i.Link.Type != "") {
+		item.Enclosure = &RssEnclosure{Url: i.Link.Href, Type: i.Link.Type, Length: i.Link.Length}
+	}
+	if i.Author != nil {
+		item.Author = i.Author.Name
+	}
+	return item
+}
+
+// create a new RssFeed with a generic Feed struct's data
+func (r *Rss) RssFeed() *RssFeed {
+	pub := anyTimeFormat(time.RFC1123Z, r.Created, r.Updated)
+	build := anyTimeFormat(time.RFC1123Z, r.Updated)
+	author := ""
+	if r.Author != nil {
+		author = r.Author.Email
+		if len(r.Author.Name) > 0 {
+			author = fmt.Sprintf("%s (%s)", r.Author.Email, r.Author.Name)
+		}
+	}
+
+	channel := &RssFeed{
+		Title:          r.Title,
+		Link:           r.Link.Href,
+		Description:    r.Description,
+		ManagingEditor: author,
+		PubDate:        pub,
+		LastBuildDate:  build,
+		Copyright:      r.Copyright,
+	}
+	for _, i := range r.Items {
+		channel.Items = append(channel.Items, newRssItem(i))
+	}
+	return channel
+}
+
+// return an XML-Ready object for an Rss object
+func (r *Rss) FeedXml() interface{} {
+	// only generate version 2.0 feeds for now
+	return r.RssFeed().FeedXml()
+
+}
+
+// return an XML-ready object for an RssFeed object
+func (r *RssFeed) FeedXml() interface{} {
+	// modified for Nyaa
+	return &rssFeedXml{Version: "2.0", Channel: r, XMLNSTorrent: "http://xmlns.nyaa.pantsu.cat/torrent/"}
+}

--- a/feeds/rss.go
+++ b/feeds/rss.go
@@ -73,9 +73,11 @@ type RssItem struct {
 	PubDate     string `xml:"pubDate,omitempty"` // created or updated
 	Source      string `xml:"source,omitempty"`
 
-	Seeders  uint32 `xml:"torrent:seeders"`  // modified for Nyaa
-	Leechers uint32 `xml:"torrent:leechers"` // modified for Nyaa
-	Hash     string `xml:"torrent:hash"`     // modified for Nyaa
+	Seeders    uint32 `xml:"torrent:seeders"`    // modified for Nyaa
+	Leechers   uint32 `xml:"torrent:leechers"`   // modified for Nyaa
+	Hash       string `xml:"torrent:hash"`       // modified for Nyaa
+	Completed  uint32 `xml:"torrent:completed"`  // modified for Nyaa
+	LastScrape string `xml:"torrent:lastScrape"` // modified for Nyaa
 }
 
 type RssEnclosure struct {
@@ -98,9 +100,12 @@ func newRssItem(i *Item) *RssItem {
 		Description: i.Description,
 		Guid:        i.Id,
 		PubDate:     anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
-
-		Seeders:  i.Torrent.Seeders,  // modified for Nyaa
-		Leechers: i.Torrent.Leechers, // modified for Nyaa
+		// modified for Nyaa
+		Seeders:    i.Torrent.Seeders,
+		Leechers:   i.Torrent.Leechers,
+		Hash:       i.Torrent.Hash,
+		Completed:  i.Torrent.Completed,
+		LastScrape: anyTimeFormat(time.RFC1123Z, i.Torrent.LastScrape),
 	}
 
 	intLength, err := strconv.ParseInt(i.Link.Length, 10, 64)

--- a/feeds/uuid.go
+++ b/feeds/uuid.go
@@ -1,0 +1,27 @@
+package feeds
+
+// relevant bits from https://github.com/abneptis/GoUUID/blob/master/uuid.go
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+type UUID [16]byte
+
+// create a new uuid v4
+func NewUUID() *UUID {
+	u := &UUID{}
+	_, err := rand.Read(u[:16])
+	if err != nil {
+		panic(err)
+	}
+
+	u[8] = (u[8] | 0x80) & 0xBf
+	u[6] = (u[6] | 0x40) & 0x4f
+	return u
+}
+
+func (u *UUID) String() string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", u[:4], u[4:6], u[6:8], u[8:10], u[10:])
+}

--- a/feeds/uuid_test.go
+++ b/feeds/uuid_test.go
@@ -1,0 +1,19 @@
+package feeds
+
+import (
+	"testing"
+)
+
+func TestUUID(t *testing.T) {
+	s := NewUUID()
+	s2 := NewUUID()
+	if len(s) != 16 {
+		t.Errorf("Expecting len of 16, got %d\n", len(s))
+	}
+	if len(s.String()) != 36 {
+		t.Errorf("Expecting uuid hex string len of 36, got %d\n", len(s.String()))
+	}
+	if s == s2 {
+		t.Errorf("Expecting different UUIDs to be different, but they are the same.\n")
+	}
+}

--- a/router/rssHandler.go
+++ b/router/rssHandler.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"github.com/ewhal/nyaa/config"
 	"github.com/ewhal/nyaa/feeds"
 	"github.com/ewhal/nyaa/util"
@@ -29,6 +30,7 @@ func RSSHandler(w http.ResponseWriter, r *http.Request) {
 	feed.Items = make([]*feeds.Item, len(torrents))
 
 	for i, torrent := range torrents {
+		fmt.Println(torrent.Hash)
 		torrentJSON := torrent.ToJSON()
 		feed.Items[i] = &feeds.Item{
 			Id:          "https://" + config.WebAddress + "/view/" + torrentJSON.ID,
@@ -38,9 +40,11 @@ func RSSHandler(w http.ResponseWriter, r *http.Request) {
 			Created:     torrent.Date,
 			Updated:     torrent.Date,
 			Torrent: &feeds.Torrent{
-				Seeders:  torrent.Seeders,
-				Leechers: torrent.Leechers,
-				Hash:     torrent.Hash,
+				Seeders:    torrent.Seeders,
+				Leechers:   torrent.Leechers,
+				Hash:       torrent.Hash,
+				Completed:  torrent.Completed,
+				LastScrape: torrent.LastScrape,
 			},
 		}
 	}

--- a/router/rssHandler.go
+++ b/router/rssHandler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ewhal/nyaa/util/search"
 	"net/http"
 	"time"
-	"fmt"
 )
 
 func RSSHandler(w http.ResponseWriter, r *http.Request) {

--- a/router/rssHandler.go
+++ b/router/rssHandler.go
@@ -2,15 +2,16 @@ package router
 
 import (
 	"github.com/ewhal/nyaa/config"
+	"github.com/ewhal/nyaa/feeds"
 	"github.com/ewhal/nyaa/util"
 	"github.com/ewhal/nyaa/util/search"
-	"github.com/gorilla/feeds"
 	"net/http"
 	"time"
 )
 
 func RSSHandler(w http.ResponseWriter, r *http.Request) {
 	_, torrents, err := search.SearchByQueryNoCount(r, 1)
+
 	if err != nil {
 		util.SendError(w, err, 400)
 		return
@@ -36,6 +37,11 @@ func RSSHandler(w http.ResponseWriter, r *http.Request) {
 			Description: string(torrentJSON.Description),
 			Created:     torrent.Date,
 			Updated:     torrent.Date,
+			Torrent: &feeds.Torrent{
+				Seeders:  torrent.Seeders,
+				Leechers: torrent.Leechers,
+				Hash:     torrent.Hash,
+			},
 		}
 	}
 	// allow cross domain AJAX requests


### PR DESCRIPTION
As suggested by #451.
Pulled  gorilla/feeds into nyaa/feeds and modified to allow for `torrent` tags.
It now supplies
`torrent:seeders`
`torrent:leechers`
`torrent:hash`
`torrent:completed`
`torrent:lastScrape`