### PR TITLE
[templates][register] remove unnecessary symbol in title

### DIFF
--- a/templates/user/register.html
+++ b/templates/user/register.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{ T "register_title" }}{{end}}
+{{define "title"}}{{ T "register_title" }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 <div class="blockBody">


### PR DESCRIPTION
When I go to /user/register in firefox page title looks like 
![screenshot_2017-05-16_22-26-51](https://cloud.githubusercontent.com/assets/892135/26124624/d351572e-3a87-11e7-8db5-388c3a86cd12.png)

Can't reproduce it in chrome. 

But when you look at raw source code it actually looks like this
![screenshot_2017-05-16_22-32-51](https://cloud.githubusercontent.com/assets/892135/26124671/fa1cdba8-3a87-11e7-9991-f4f297eefa46.png)
